### PR TITLE
Fix pkl-gen-go when installed via `go install`

### DIFF
--- a/cmd/pkl-gen-go/pkl-gen-go.go
+++ b/cmd/pkl-gen-go/pkl-gen-go.go
@@ -111,7 +111,8 @@ var printVersion bool
 
 // The version of pkl-gen-go.
 //
-// This gets replaced by ldflags during release build
+// This gets replaced by ldflags when built through CI,
+// or by init when installed via go install.
 var Version = "development"
 
 func init() {

--- a/cmd/pkl-gen-go/pkl-gen-go.go
+++ b/cmd/pkl-gen-go/pkl-gen-go.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
+	"strings"
 
 	"github.com/apple/pkl-go/cmd/pkl-gen-go/generatorsettings"
 	"github.com/apple/pkl-go/cmd/pkl-gen-go/pkg"
@@ -111,6 +113,14 @@ var printVersion bool
 //
 // This gets replaced by ldflags during release build
 var Version = "development"
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Version == "" || Version != "development" {
+		return
+	}
+	Version = strings.TrimPrefix(info.Main.Version, "v")
+}
 
 func fileExists(filepath string) bool {
 	_, err := os.Stat(filepath)


### PR DESCRIPTION
This fixes an issue where the pkl-gen-go binary
fails to evaluate when run via `go install`,
because its version information is incorrect.