### PR TITLE
Support Projects loaded from arbitrary URIs

### DIFF
--- a/DEVELOPMENT.adoc
+++ b/DEVELOPMENT.adoc
@@ -1,0 +1,43 @@
+:uri-pkl-repo: https://github.com/apple/pkl
+
+= Pkl Go Development Guide
+
+== Debugging the Pkl Server
+
+The pkl-go evaluator API runs `pkl server` as a subprocess, which presents obstacles for directly debugging the server process.
+It is possible to
+
+*Debug Stub Setup*
+
+. Create a file named `debugpkl`
+. Mark the file executable with `chmod +x debugpkl`
+. Populate the file with this content (note: the path to the executable will depend on where the Pkl repo is cloned):
+
+[,shell]
+----
+#!/bin/sh
+
+exec java -agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y -jar /path/to/pkl/pkl-cli/build/executable/jpkl "$@"
+----
+
+
+*IntelliJ IDEA Setup:*
+
+. Open the {uri-pkl-repo}[pkl] project
+. Build `jpkl` by running `./gradlew javaExecutable` so it is available to the script defined above
+. Run > Edit Configurations...
+. Add a new "Remote JVM Debug" configuration
+. Provide a name, eg. `debugpkl`
+. Under "Configuration", select the "Listen to remote JVM" debugger mode
+. Enable "Auto restart"
+. Ensure Host is "localhost" and Port is "5005"
+
+*Usage*
+
+. Configure pkl-go to use `debugpkl` as the server executable: `export PKL_EXEC=./debugpkl`
+. Optionally, turn on extra debug output: `export PKL_DEBUG=1`
+. Define breakpoints as desired in the Pkl codebase using IntelliJ
+. In IntelliJ, start debugging the "Remote JVM Debug" configuration defined above
+. Execute the process using pkl-go
+
+When the Pkl server execution reaches a defined breakpoint, it will pause and activate the debugger in IntelliJ.

--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -83,11 +83,11 @@ type EvaluatorOptions struct {
 	// Attempting to read past the root directory is an error.
 	RootDir string
 
-	// ProjectFileURI is the project directory for the evaluator.
+	// ProjectBaseURI sets the project base path for the evaluator.
 	//
 	// Setting this determines how Pkl resolves dependency notation imports.
-	// It causes Pkl to look for the resolved dependencies relative to this directory,
-	// and load resolved dependencies from a PklProject.deps.json file inside this directory.
+	// It causes Pkl to look for the resolved dependencies relative to this base URI,
+	// and load resolved dependencies from `PklProject.deps.json` within the base path represented.
 	//
 	// NOTE:
 	// Setting this option is not equivalent to setting the `--project-dir` flag from the CLI.

--- a/pkl/reader.go
+++ b/pkl/reader.go
@@ -22,6 +22,7 @@ import (
 // Reader is the base implementation shared by a ResourceReader and a ModuleReader.
 type Reader interface {
 	// Scheme returns the scheme part of the URL that this reader can read.
+	// The value should be the URI scheme up to (not including) ":"
 	Scheme() string
 
 	// IsGlobbable tells if this reader supports globbing via Pkl's `import*` and `glob*` keywords


### PR DESCRIPTION
Builds on https://github.com/apple/pkl/pull/255 to allow fully in-memory evaluation of Pkl codebases using projects.

* In `EvaluatorOptions`, replace `ProjectDir` with `ProjectBaseURI` (API breaking)
* `WithResourceReader` and `WithModuleReader` now append `:` to the scheme when appending to the allow-lists
* Correct typo in `DeclaredProjectDepenedencies` (API breaking)
* Add DEVELOPMENT.adoc with instructions on how to debug the `pkl server` subprocess
* Miscellaneous doc comment clarifications