### PR TITLE
Support project dir when using pkl-gen-go

### DIFF
--- a/cmd/pkl-gen-go/generatorsettings/GeneratorSettings.pkl.go
+++ b/cmd/pkl-gen-go/generatorsettings/GeneratorSettings.pkl.go
@@ -67,6 +67,11 @@ type GeneratorSettings struct {
 	// This corresponds to the `--allowed-resources` flag in the Pkl CLI.
 	AllowedResources []string `pkl:"allowedResources"`
 
+	// The project directory to control dependency and evaluator settings during codegen.
+	//
+	// This corresponds to the `--project-dir` flag in the Pkl CLI.
+	ProjctDir *string `pkl:"projctDir"`
+
 	// Print out the names of the files that will be generated, but skip writing anything to disk.
 	DryRun bool `pkl:"dryRun"`
 }

--- a/cmd/pkl-gen-go/generatorsettings/GeneratorSettings.pkl.go
+++ b/cmd/pkl-gen-go/generatorsettings/GeneratorSettings.pkl.go
@@ -70,10 +70,14 @@ type GeneratorSettings struct {
 	// The project directory to control dependency and evaluator settings during codegen.
 	//
 	// This corresponds to the `--project-dir` flag in the Pkl CLI.
-	ProjctDir *string `pkl:"projctDir"`
+	// Relative paths are resolved against the enclosing file.
+	ProjectDir *string `pkl:"projectDir"`
 
 	// Print out the names of the files that will be generated, but skip writing anything to disk.
 	DryRun bool `pkl:"dryRun"`
+
+	// The URI of this module, used to resolve [projectDir].
+	Uri string `pkl:"uri"`
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a GeneratorSettings

--- a/cmd/pkl-gen-go/pkl-gen-go.go
+++ b/cmd/pkl-gen-go/pkl-gen-go.go
@@ -65,22 +65,10 @@ CONFIGURING OUTPUT PATH
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if printVersion {
-			print(Version)
+			fmt.Println(Version)
 			return nil
 		}
-		evaluator, err := pkl.NewEvaluator(
-			context.Background(),
-			pkl.PreconfiguredOptions,
-			func(options *pkl.EvaluatorOptions) {
-				options.Logger = pkl.StderrLogger
-				if len(settings.AllowedModules) > 0 {
-					options.AllowedModules = settings.AllowedModules
-				}
-				if len(settings.AllowedResources) > 0 {
-					options.AllowedResources = settings.AllowedResources
-				}
-			},
-		)
+		evaluator, err := newEvaluator()
 		if err != nil {
 			return err
 		}
@@ -102,6 +90,29 @@ CONFIGURING OUTPUT PATH
 		}
 		return cobra.ExactArgs(1)(cmd, args)
 	},
+}
+
+func newEvaluator() (pkl.Evaluator, error) {
+	projectDirFlag := ""
+	if settings.ProjctDir != nil {
+		projectDirFlag = *settings.ProjctDir
+	}
+	projectDir := findProjectDir(projectDirFlag)
+	if projectDir == "" {
+		return pkl.NewEvaluator(context.Background(), evaluatorOptions)
+	}
+	return pkl.NewProjectEvaluator(context.Background(), projectDir, evaluatorOptions)
+}
+
+func evaluatorOptions(opts *pkl.EvaluatorOptions) {
+	pkl.MaybePreconfiguredOptions(opts)
+	opts.Logger = pkl.StderrLogger
+	if len(settings.AllowedModules) > 0 {
+		opts.AllowedModules = settings.AllowedModules
+	}
+	if len(settings.AllowedResources) > 0 {
+		opts.AllowedResources = settings.AllowedResources
+	}
 }
 
 var settings *generatorsettings.GeneratorSettings
@@ -146,6 +157,52 @@ func generatorSettingsSource() *pkl.ModuleSource {
 	return pkl.UriSource(fmt.Sprintf("package://pkg.pkl-lang.org/pkl-go/pkl.golang@%s#/GeneratorSettings.pkl", Version))
 }
 
+// mimick logic for finding project dir in the pkl CLI.
+func doFindProjectDir(dir string) string {
+	if fileExists(filepath.Join(dir, "PklProject")) {
+		return dir
+	}
+	parent := filepath.Dir(dir)
+	if parent == dir {
+		return ""
+	}
+	return doFindProjectDir(parent)
+}
+
+func findProjectDir(projectDirFlag string) string {
+	if projectDirFlag != "" {
+		return projectDirFlag
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return doFindProjectDir(cwd)
+}
+
+func loadGeneratorSettings(generatorSettingsPath string, projectDirFlag string) (*generatorsettings.GeneratorSettings, error) {
+	projectDir := findProjectDir(projectDirFlag)
+	var evaluator pkl.Evaluator
+	var err error
+	if projectDir != "" {
+		evaluator, err = pkl.NewProjectEvaluator(context.Background(), projectDir, pkl.PreconfiguredOptions)
+	} else {
+		evaluator, err = pkl.NewEvaluator(context.Background(), pkl.PreconfiguredOptions)
+	}
+	if err != nil {
+		panic(err)
+	}
+	var source *pkl.ModuleSource
+	if generatorSettingsPath != "" {
+		source = pkl.FileSource(generatorSettingsPath)
+	} else if fileExists("generator-settings.pkl") {
+		source = pkl.FileSource("generator-settings.pkl")
+	} else {
+		source = generatorSettingsSource()
+	}
+	return generatorsettings.Load(context.Background(), evaluator, source)
+}
+
 func init() {
 	flags := command.Flags()
 	var generatorSettingsPath string
@@ -155,6 +212,7 @@ func init() {
 	var allowedModules []string
 	var allowedResources []string
 	var dryRun bool
+	var projectDir string
 	flags.StringVar(&generatorSettingsPath, "generator-settings", "", "The path to a generator settings file")
 	flags.StringVar(&generateScript, "generate-script", "", "The Generate.pkl script to use")
 	flags.StringToStringVar(&mappings, "mapping", nil, "The mapping of a Pkl module name to a Go package name")
@@ -163,30 +221,14 @@ func init() {
 	flags.BoolVar(&suppressWarnings, "suppress-format-warning", false, "Suppress warnings around formatting issues")
 	flags.StringSliceVar(&allowedModules, "allowed-modules", nil, "URI patterns that determine which modules can be loaded and evaluated")
 	flags.StringSliceVar(&allowedResources, "allowed-resources", nil, "URI patterns that determine which resources can be loaded and evaluated")
+	flags.StringVar(&projectDir, "project-dir", "", "The project directory to load dependency and evaluator settings from")
 	flags.BoolVar(&dryRun, "dry-run", false, "Print out the names of the files that will be generated, but don't write any files")
 	flags.BoolVar(&printVersion, "version", false, "Print the version and exit")
-	if err := flags.Parse(os.Args); err != nil && !errors.Is(err, pflag.ErrHelp) {
+	var err error
+	if err = flags.Parse(os.Args); err != nil && !errors.Is(err, pflag.ErrHelp) {
 		panic(err)
 	}
-	var err error
-	if generatorSettingsPath != "" {
-		settings, err = generatorsettings.LoadFromPath(context.Background(), generatorSettingsPath)
-	} else if fileExists("generator-settings.pkl") {
-		settings, err = generatorsettings.LoadFromPath(context.Background(), "generator-settings.pkl")
-	} else {
-		var evaluator pkl.Evaluator
-		evaluator, err = pkl.NewEvaluator(context.Background(), pkl.PreconfiguredOptions)
-		if err != nil {
-			panic(err)
-		}
-		//goland:noinspection GoUnhandledErrorResult
-		defer evaluator.Close()
-		settings, err = generatorsettings.Load(
-			context.Background(),
-			evaluator,
-			generatorSettingsSource(),
-		)
-	}
+	settings, err = loadGeneratorSettings(generatorSettingsPath, projectDir)
 	if err != nil {
 		panic(err)
 	}
@@ -204,6 +246,9 @@ func init() {
 	}
 	if len(allowedResources) > 0 {
 		settings.AllowedResources = allowedResources
+	}
+	if projectDir != "" {
+		settings.ProjctDir = &projectDir
 	}
 	settings.DryRun = dryRun
 }

--- a/codegen/src/GeneratorSettings.pkl
+++ b/codegen/src/GeneratorSettings.pkl
@@ -18,6 +18,7 @@
 module pkl.golang.GeneratorSettings
 
 import "go.pkl"
+import "pkl:reflect"
 
 local version = read("resources/VERSION.txt").text.trim()
 
@@ -82,7 +83,13 @@ allowedResources: Listing<String>
 /// The project directory to control dependency and evaluator settings during codegen.
 ///
 /// This corresponds to the `--project-dir` flag in the Pkl CLI.
-projctDir: String?
+/// Relative paths are resolved against the enclosing file.
+///
+/// Paths must use `/` as the path separator.
+projectDir: String?
 
 /// Print out the names of the files that will be generated, but skip writing anything to disk.
 dryRun: Boolean = false
+
+/// The URI of this module, used to resolve [projectDir].
+fixed uri: String = reflect.Module(module).uri

--- a/codegen/src/GeneratorSettings.pkl
+++ b/codegen/src/GeneratorSettings.pkl
@@ -79,5 +79,10 @@ allowedModules: Listing<String>
 /// This corresponds to the `--allowed-resources` flag in the Pkl CLI.
 allowedResources: Listing<String>
 
+/// The project directory to control dependency and evaluator settings during codegen.
+///
+/// This corresponds to the `--project-dir` flag in the Pkl CLI.
+projctDir: String?
+
 /// Print out the names of the files that will be generated, but skip writing anything to disk.
 dryRun: Boolean = false

--- a/generator-settings.pkl
+++ b/generator-settings.pkl
@@ -19,3 +19,5 @@ amends "codegen/src/GeneratorSettings.pkl"
 basePath = "github.com/apple/pkl-go"
 
 generatorScriptPath = "codegen/src/Generator.pkl"
+
+projectDir = "codegen/src"

--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -349,3 +349,25 @@ var PreconfiguredOptions = func(opts *EvaluatorOptions) {
 	WithDefaultCacheDir(opts)
 	opts.Logger = NoopLogger
 }
+
+// MaybePreconfiguredOptions is like PreconfiguredOptions, except it only applies options
+// if they have not already been set.
+//
+// It panics if the home directory cannot be determined.
+var MaybePreconfiguredOptions = func(opts *EvaluatorOptions) {
+	if len(opts.AllowedResources) == 0 {
+		WithDefaultAllowedResources(opts)
+	}
+	if len(opts.Env) == 0 {
+		WithOsEnv(opts)
+	}
+	if len(opts.AllowedModules) == 0 {
+		WithDefaultAllowedModules(opts)
+	}
+	if opts.CacheDir == "" {
+		WithDefaultCacheDir(opts)
+	}
+	if opts.Logger == nil {
+		opts.Logger = NoopLogger
+	}
+}

--- a/pkl/internal/msgapi/outgoing.go
+++ b/pkl/internal/msgapi/outgoing.go
@@ -84,7 +84,7 @@ type ProjectOrDependency struct {
 	Type           string                          `msgpack:"type"`
 	ProjectFileUri string                          `msgpack:"projectFileUri,omitempty"`
 	Checksums      *Checksums                      `msgpack:"checksums,omitempty"`
-	Dependencies   map[string]*ProjectOrDependency `msgpack:"dependencies,omitempty"`
+	Dependencies   map[string]*ProjectOrDependency `msgpack:"dependencies"`
 }
 
 type Checksums struct {


### PR DESCRIPTION
* Add a `--project-dir` flag to the CLI
* Add a `projectSettings` flag to the code generator settings file
* Infer project dir from CWD if no option is supplied (same behavior as CLI)
* Add a new options builder called `MaybePreconfiguredOptions` (follow behavior of pkl CLI)