### PR TITLE
CircleCI improvements

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -1,4 +1,4 @@
-amends ".../pkl-project-commons/packages/pkl.impl.circleci/PklCI.pkl"
+amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.0.2#/PklCI.pkl"
 
 prb {
   jobs {
@@ -8,7 +8,7 @@ prb {
 
 main = buildWorkflow
 
-local pklVersion = "0.25.1"
+local pklVersion = "0.25.2"
 local pklBinary = "https://repo1.maven.org/maven2/org/pkl-lang/pkl-cli-linux-amd64/\(pklVersion)/pkl-cli-linux-amd64-\(pklVersion).bin"
 
 release = (buildWorkflow) {
@@ -186,7 +186,7 @@ jobs {
 local goJob: Job = new {
   docker {
     new {
-      image = "cimg/go:1.19"
+      image = "cimg/go:1.21"
     }
   }
   steps {
@@ -196,7 +196,7 @@ local goJob: Job = new {
 
 local buildJobs = jobs.keys.filter((it) -> it.startsWith("build-"))
 
-local buildWorkflow = new Workflow {
+local buildWorkflow: Workflow = new {
   jobs {
     "test"
     for (jobName in buildJobs) {

--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -9,7 +9,7 @@ prb {
 main = buildWorkflow
 
 local pklVersion = "0.25.2"
-local pklBinary = "https://repo1.maven.org/maven2/org/pkl-lang/pkl-cli-linux-amd64/\(pklVersion)/pkl-cli-linux-amd64-\(pklVersion).bin"
+local pklBinary = "https://github.com/apple/pkl/releases/download/\(pklVersion)/pkl-linux-amd64"
 
 release = (buildWorkflow) {
   jobs {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     - checkout
     - run:
         command: |-
-          curl -L -o pkl.bin https://repo1.maven.org/maven2/org/pkl-lang/pkl-cli-linux-amd64/0.25.1/pkl-cli-linux-amd64-0.25.1.bin
+          curl -L -o pkl.bin https://repo1.maven.org/maven2/org/pkl-lang/pkl-cli-linux-amd64/0.25.2/pkl-cli-linux-amd64-0.25.2.bin
           chmod +x pkl.bin
           export PKL_EXEC=$(pwd)/pkl.bin
           go install github.com/jstemmer/go-junit-report/v2@latest
@@ -109,7 +109,7 @@ jobs:
     - checkout
     - run:
         command: |-
-          curl -L -o pkl.bin https://repo1.maven.org/maven2/org/pkl-lang/pkl-cli-linux-amd64/0.25.1/pkl-cli-linux-amd64-0.25.1.bin
+          curl -L -o pkl.bin https://repo1.maven.org/maven2/org/pkl-lang/pkl-cli-linux-amd64/0.25.2/pkl-cli-linux-amd64-0.25.2.bin
           chmod +x pkl.bin
           ./pkl.bin project package codegen/src/ --output-path out/pkl-package/
         name: Creating Pkl package
@@ -195,7 +195,6 @@ workflows:
     - test:
         requires:
         - hold
-        - pr-approval/authenticate
     when:
       matches:
         value: << pipeline.git.branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     - checkout
     - run:
         command: |-
-          curl -L -o pkl.bin https://repo1.maven.org/maven2/org/pkl-lang/pkl-cli-linux-amd64/0.25.2/pkl-cli-linux-amd64-0.25.2.bin
+          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.2/pkl-linux-amd64
           chmod +x pkl.bin
           export PKL_EXEC=$(pwd)/pkl.bin
           go install github.com/jstemmer/go-junit-report/v2@latest
@@ -109,7 +109,7 @@ jobs:
     - checkout
     - run:
         command: |-
-          curl -L -o pkl.bin https://repo1.maven.org/maven2/org/pkl-lang/pkl-cli-linux-amd64/0.25.2/pkl-cli-linux-amd64-0.25.2.bin
+          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.2/pkl-linux-amd64
           chmod +x pkl.bin
           ./pkl.bin project package codegen/src/ --output-path out/pkl-package/
         name: Creating Pkl package


### PR DESCRIPTION
* Switch to package dependency
* Bump Go image to 1.21
* prbs don't depend on pr-approval/authenticate
* Use pkl 0.25.2