### PR TITLE
Fix typos in code comments

### DIFF
--- a/pkl/evaluator_manager_exec.go
+++ b/pkl/evaluator_manager_exec.go
@@ -64,7 +64,7 @@ type execEvaluator struct {
 	in     chan msgapi.IncomingMessage
 	out    chan msgapi.OutgoingMessage
 	closed chan error
-	// exited is a flag that indicates evaluator was closed explicity
+	// exited is a flag that indicates evaluator was closed explicitly
 	exited     atomicBool
 	version    string
 	pklCommand []string

--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -261,7 +261,7 @@ var WithResourceReader = func(reader ResourceReader) func(opts *EvaluatorOptions
 	}
 }
 
-// WithModuleReader sets up the given module reader, and also adds the reader's scheme to the]
+// WithModuleReader sets up the given module reader, and also adds the reader's scheme to the
 // evaluator's allowed modules list.
 var WithModuleReader = func(reader ModuleReader) func(opts *EvaluatorOptions) {
 	return func(opts *EvaluatorOptions) {

--- a/pkl/reader.go
+++ b/pkl/reader.go
@@ -31,7 +31,7 @@ type Reader interface {
 	// Hierarchical URIs are URIs that have hierarchy elements like host, origin, query, and
 	// fragment.
 	//
-	// A hierarchical URI must start with a "/" in its scheme specific part. For example,  consider
+	// A hierarchical URI must start with a "/" in its scheme specific part. For example, consider
 	// the following two URIS:
 	//
 	//   flintstone:/persons/fred.pkl


### PR DESCRIPTION
This commit addresses several typographical errors found within the comments sections of evaluator_options.go, reader.go, and evaluator_manager_exec.go.