### PR TITLE
fix: avoid int overflow errors with DurationUnit && DataSizeUnit

### DIFF
--- a/pkl/values.go
+++ b/pkl/values.go
@@ -101,7 +101,7 @@ func (d *Duration) GoDuration() time.Duration {
 }
 
 // DurationUnit represents unit of a Duration.
-type DurationUnit int
+type DurationUnit int64
 
 const (
 	Nanosecond  DurationUnit = 1
@@ -198,7 +198,7 @@ func (d *DataSize) ToUnit(unit DataSizeUnit) DataSize {
 }
 
 // DataSizeUnit represents unit of a DataSize.
-type DataSizeUnit int
+type DataSizeUnit int64
 
 var _ encoding.BinaryUnmarshaler = new(DataSizeUnit)
 


### PR DESCRIPTION
I hit this bug when trying to use `goreleaser` on a project using `pkl-go` as it failed with errors like the following. 

Note I'm not sure why `goreleaser` finds these issues but other go targets don't; I guess its one of the golang linters maybe?

```bash
pkl/values.go:111:29: Second * 60 (constant 60000000000 of type DurationUnit) overflows int;
pkl/values.go:238:7: Terabytes (untyped int constant 1000000000000) overflows int;
pkl/values.go:240:7: Tebibytes (untyped int constant 1099511627776) overflows int;
pkl/values.go:242:7: Petabytes (untyped int constant 1000000000000000) overflows int;
pkl/values.go:244:7: Pebibytes (untyped int constant 1125899906842624) overflows int;
pkl/values.go:279:10: cannot use Terabytes (untyped int constant 1000000000000) as DataSizeUnit value in return statement (overflows);
pkl/values.go:281:10: cannot use Tebibytes (untyped int constant 1099511627776) as DataSizeUnit value in return statement (overflows);
pkl/values.go:283:10: cannot use Petabytes (untyped int constant 1000000000000000) as DataSizeUnit value in return statement (overflows);
pkl/values.go:285:10: cannot use Pebibytes (untyped int constant 1125899906842624) as DataSizeUnit value in return statement (overflows);
```