### PR TITLE
fix: handle pkl sub classes / extending structs in custom classes

### DIFF
--- a/pkl/test_fixtures/custom/house.go
+++ b/pkl/test_fixtures/custom/house.go
@@ -1,0 +1,17 @@
+package custom
+
+type Shape struct {
+	Area int `pkl:"area"`
+}
+
+type House struct {
+	Shape
+
+	Bedrooms int `pkl:"bedrooms"`
+
+	Bathrooms int `pkl:"bathrooms"`
+}
+
+type CustomClasses struct {
+	House *House `pkl:"house"`
+}

--- a/pkl/test_fixtures/custom/house.pkl
+++ b/pkl/test_fixtures/custom/house.pkl
@@ -1,0 +1,31 @@
+// ===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ===----------------------------------------------------------------------===//
+module custom
+
+house: House = new {
+  area = 2000
+  bedrooms = 3
+  bathrooms = 2
+}
+
+abstract class Shape {
+  area: Int
+}
+
+class House extends Shape {
+  bedrooms: Int
+  bathrooms: Int
+}

--- a/pkl/unmarshal_test.go
+++ b/pkl/unmarshal_test.go
@@ -17,7 +17,10 @@ package pkl_test
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
+	"github.com/apple/pkl-go/pkl/test_fixtures/custom"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	unknowntype "github.com/apple/pkl-go/pkl/test_fixtures/gen/unknown_type"
@@ -82,6 +85,9 @@ var anies []byte
 
 //go:embed test_fixtures/msgpack/unknown_type.pkl.msgpack
 var unknownType []byte
+
+//go:embed test_fixtures/custom/house.pkl
+var customHousePkl []byte
 
 func TestUnmarshall_Primitives(t *testing.T) {
 	var res primitives.Primitives
@@ -427,4 +433,24 @@ func TestUnmarshal_UnknownType(t *testing.T) {
 	err := pkl.Unmarshal(unknownType, &res)
 	assert.Error(t, err)
 	assert.Equal(t, "cannot decode Pkl value of type `PcfRenderer` into Go type `interface {}`. Define a custom mapping for this using `pkl.RegisterMapping`", err.Error())
+}
+
+func TestUnmarshal_Custom(t *testing.T) {
+	evaluator, err := pkl.NewEvaluator(context.Background(), pkl.PreconfiguredOptions)
+	require.NoError(t, err, "failed to create evaluator")
+	defer evaluator.Close()
+
+	var res custom.CustomClasses
+	err = evaluator.EvaluateModule(context.Background(), pkl.TextSource(string(customHousePkl)), &res)
+	require.NoError(t, err, "failed to evaluate moduler")
+
+	assert.Equal(t, custom.CustomClasses{
+		House: &custom.House{
+			Shape: custom.Shape{
+				Area: 2000,
+			},
+			Bedrooms:  3,
+			Bathrooms: 2,
+		},
+	}, res)
 }

--- a/pkl/unmarshal_test.go
+++ b/pkl/unmarshal_test.go
@@ -437,12 +437,12 @@ func TestUnmarshal_UnknownType(t *testing.T) {
 
 func TestUnmarshal_Custom(t *testing.T) {
 	evaluator, err := pkl.NewEvaluator(context.Background(), pkl.PreconfiguredOptions)
-	require.NoError(t, err, "failed to create evaluator")
+	require.NoError(t, err, "failed to create pkl evaluator")
 	defer evaluator.Close()
 
 	var res custom.CustomClasses
 	err = evaluator.EvaluateModule(context.Background(), pkl.TextSource(string(customHousePkl)), &res)
-	require.NoError(t, err, "failed to evaluate moduler")
+	require.NoError(t, err, "failed to evaluate pkl module")
 
 	assert.Equal(t, custom.CustomClasses{
 		House: &custom.House{


### PR DESCRIPTION
add support for unmarshalling into anonymous go struct fields from pkl sub-classes

so we can create custom go structs using inheritence and unmarshal pkl to them