### PR TITLE
Check if manager is closed before closing evaluator

### DIFF
--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -247,6 +247,10 @@ func (m *evaluatorManager) interrupted(evaluatorId int64) (chan error, func()) {
 
 // closeEvaluator closes the provided evaluator.
 func (m *evaluatorManager) closeEvaluator(ev *evaluator) {
+	// if the manager itself is closed, there's nothing to do.
+	if m.closed.get() {
+		return
+	}
 	m.impl.outChan() <- &msgapi.CloseEvaluator{EvaluatorId: ev.evaluatorId}
 	m.evaluators.Delete(ev.evaluatorId)
 	ev.closed = true


### PR DESCRIPTION
Addresses a possible race condition where a runtime panic might happen if the manager is already closed, when closing an evaluator.