### PR TITLE
Bump PKL version to 0.25.3

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -8,7 +8,7 @@ prb {
 
 main = buildWorkflow
 
-local pklVersion = "0.25.2"
+local pklVersion = "0.25.3"
 local pklBinary = "https://github.com/apple/pkl/releases/download/\(pklVersion)/pkl-linux-amd64"
 
 release = (buildWorkflow) {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     - checkout
     - run:
         command: |-
-          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.2/pkl-linux-amd64
+          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.3/pkl-linux-amd64
           chmod +x pkl.bin
           export PKL_EXEC=$(pwd)/pkl.bin
           go install github.com/jstemmer/go-junit-report/v2@latest
@@ -109,7 +109,7 @@ jobs:
     - checkout
     - run:
         command: |-
-          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.2/pkl-linux-amd64
+          curl -L -o pkl.bin https://github.com/apple/pkl/releases/download/0.25.3/pkl-linux-amd64
           chmod +x pkl.bin
           ./pkl.bin project package codegen/src/ --output-path out/pkl-package/
         name: Creating Pkl package

--- a/pkl/evaluator_manager_test.go
+++ b/pkl/evaluator_manager_test.go
@@ -34,7 +34,7 @@ type fakeEvaluatorImpl struct {
 
 func (f *fakeEvaluatorImpl) getVersion() (string, error) {
 	if f.version == "" {
-		return "0.23.2", nil
+		return "0.25.3", nil
 	}
 	return f.version, nil
 }


### PR DESCRIPTION
The PKL version used in the project has been updated from 0.25.2 to 0.25.3 in the .circleci/config files and in evaluator_manager_test.go.