### PR TITLE
Chore: update variable declaration format and file permission syntax

### DIFF
--- a/cmd/internal/add-license-header/add-license-header.go
+++ b/cmd/internal/add-license-header/add-license-header.go
@@ -75,7 +75,7 @@ func main() {
 			continue
 		}
 		newContents := licenseHeader + contentsStr
-		if err = os.WriteFile(absolutePath, []byte(newContents), 0644); err != nil {
+		if err = os.WriteFile(absolutePath, []byte(newContents), 0o644); err != nil {
 			panic(err)
 		}
 		fmt.Println("Wrote license header to " + file)

--- a/cmd/internal/gen-fixtures/gen-fixtures.go
+++ b/cmd/internal/gen-fixtures/gen-fixtures.go
@@ -44,7 +44,7 @@ func evaluateCollections(evaluator pkl.Evaluator, fixturesDir string) {
 			panic(err)
 		}
 		outPath := path.Join(fixturesDir, "msgpack", fmt.Sprintf("collections.%s.msgpack", expr))
-		if err = os.WriteFile(outPath, outBytes, 0666); err != nil {
+		if err = os.WriteFile(outPath, outBytes, 0o666); err != nil {
 			panic(err)
 		}
 		fmt.Printf("Wrote file %s\n", outPath)
@@ -65,10 +65,10 @@ func makeMsgpack(evaluator pkl.Evaluator, fixturesDir string, files []os.DirEntr
 			panic(err)
 		}
 		outPath := path.Join(fixturesDir, "msgpack", file.Name()+".msgpack")
-		if err = os.MkdirAll(path.Dir(outPath), 0750); err != nil {
+		if err = os.MkdirAll(path.Dir(outPath), 0o750); err != nil {
 			panic(err)
 		}
-		if err = os.WriteFile(outPath, outBytes, 0600); err != nil {
+		if err = os.WriteFile(outPath, outBytes, 0o600); err != nil {
 			panic(err)
 		}
 		fmt.Printf("Wrote file %s\n", outPath)

--- a/cmd/internal/gen-snippets/gen-snippets.go
+++ b/cmd/internal/gen-snippets/gen-snippets.go
@@ -72,7 +72,7 @@ func makeGoCode(evaluator pkl.Evaluator, snippetsDir string) {
 			basename := strings.TrimSuffix(filepath.Base(file.Name()), ".pkl")
 			errContents := strings.ReplaceAll(err.Error(), codegenDir, "<codegen_dir>")
 			errContents = stripLineNumbers(errContents)
-			if err = os.WriteFile(path.Join(outputDir, basename), []byte(errContents), 0666); err != nil {
+			if err = os.WriteFile(path.Join(outputDir, basename), []byte(errContents), 0o666); err != nil {
 				panic(err)
 			}
 		} else if err != nil {

--- a/cmd/pkl-gen-go/pkg/generate.go
+++ b/cmd/pkl-gen-go/pkg/generate.go
@@ -171,10 +171,10 @@ func GenerateGo(
 			diffs[filename] = diff
 		}
 		out := path.Join(outputPath, filename)
-		if err = os.MkdirAll(path.Dir(out), 0777); err != nil {
+		if err = os.MkdirAll(path.Dir(out), 0o777); err != nil {
 			return err
 		}
-		if err = os.WriteFile(out, formatted, 0666); err != nil {
+		if err = os.WriteFile(out, formatted, 0o666); err != nil {
 			return err
 		}
 		fmt.Println(out)

--- a/cmd/pkl-gen-go/pkl-gen-go.go
+++ b/cmd/pkl-gen-go/pkl-gen-go.go
@@ -125,10 +125,12 @@ func evaluatorOptions(opts *pkl.EvaluatorOptions) {
 	}
 }
 
-var settings *generatorsettings.GeneratorSettings
-var suppressWarnings bool
-var outputPath string
-var printVersion bool
+var (
+	settings         *generatorsettings.GeneratorSettings
+	suppressWarnings bool
+	outputPath       string
+	printVersion     bool
+)
 
 // The version of pkl-gen-go.
 //

--- a/pkl/decode_struct.go
+++ b/pkl/decode_struct.go
@@ -37,8 +37,10 @@ type structField struct {
 
 var objectType = reflect.TypeOf(Object{})
 
-var sliceOfEmptyInterface []interface{}
-var emptyInterfaceType = reflect.TypeOf(sliceOfEmptyInterface).Elem()
+var (
+	sliceOfEmptyInterface []interface{}
+	emptyInterfaceType    = reflect.TypeOf(sliceOfEmptyInterface).Elem()
+)
 
 // decodeStruct decodes into an object represented by typ.
 // If outValue is not nil, writes fields onto outValue.

--- a/pkl/evaluator_manager_exec.go
+++ b/pkl/evaluator_manager_exec.go
@@ -70,7 +70,7 @@ type execEvaluator struct {
 	exited      atomicBool
 	version     string
 	pklCommand  []string
-  processDone chan struct{}
+	processDone chan struct{}
 }
 
 func (e *execEvaluator) inChan() chan msgapi.IncomingMessage {

--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -157,7 +157,7 @@ func (p *ProjectDependencies) toMessage() map[string]*msgapi.ProjectOrDependency
 	if p == nil {
 		return nil
 	}
-	var ret = make(map[string]*msgapi.ProjectOrDependency, len(p.LocalDependencies)+len(p.RemoteDependencies))
+	ret := make(map[string]*msgapi.ProjectOrDependency, len(p.LocalDependencies)+len(p.RemoteDependencies))
 	for name, dep := range p.LocalDependencies {
 		ret[name] = dep.toMessage()
 	}

--- a/pkl/evaluator_test.go
+++ b/pkl/evaluator_test.go
@@ -39,7 +39,7 @@ amends "pkl:Project"
 dependencies {
   ["uri"] { uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.0" }
 }
-`), 0644)
+`), 0o644)
 	_ = os.WriteFile(tempDir+"/PklProject.deps.json", []byte(`
 {
   "schemaVersion": 1,
@@ -53,12 +53,12 @@ dependencies {
     }
   }
 }
-`), 0644)
+`), 0o644)
 	_ = os.WriteFile(tempDir+"/main.pkl", []byte(`
 import "@uri/URI.pkl"
 
 uri = URI.parse("https://www.example.com").toString()
-`), 0644)
+`), 0o644)
 	return tempDir
 }
 

--- a/pkl/internal/msgapi/incoming.go
+++ b/pkl/internal/msgapi/incoming.go
@@ -29,13 +29,15 @@ type incomingMessageImpl struct{}
 
 func (r incomingMessageImpl) incomingMessage() {}
 
-var _ IncomingMessage = (*CreateEvaluatorResponse)(nil)
-var _ IncomingMessage = (*EvaluateResponse)(nil)
-var _ IncomingMessage = (*ReadResource)(nil)
-var _ IncomingMessage = (*ReadModule)(nil)
-var _ IncomingMessage = (*Log)(nil)
-var _ IncomingMessage = (*ListResources)(nil)
-var _ IncomingMessage = (*ListModules)(nil)
+var (
+	_ IncomingMessage = (*CreateEvaluatorResponse)(nil)
+	_ IncomingMessage = (*EvaluateResponse)(nil)
+	_ IncomingMessage = (*ReadResource)(nil)
+	_ IncomingMessage = (*ReadModule)(nil)
+	_ IncomingMessage = (*Log)(nil)
+	_ IncomingMessage = (*ListResources)(nil)
+	_ IncomingMessage = (*ListModules)(nil)
+)
 
 type CreateEvaluatorResponse struct {
 	incomingMessageImpl

--- a/pkl/internal/msgapi/outgoing.go
+++ b/pkl/internal/msgapi/outgoing.go
@@ -25,13 +25,15 @@ type OutgoingMessage interface {
 	ToMsgPack() ([]byte, error)
 }
 
-var _ OutgoingMessage = (*CreateEvaluator)(nil)
-var _ OutgoingMessage = (*CloseEvaluator)(nil)
-var _ OutgoingMessage = (*Evaluate)(nil)
-var _ OutgoingMessage = (*ReadResourceResponse)(nil)
-var _ OutgoingMessage = (*ReadModuleResponse)(nil)
-var _ OutgoingMessage = (*ListResourcesResponse)(nil)
-var _ OutgoingMessage = (*ListModulesResponse)(nil)
+var (
+	_ OutgoingMessage = (*CreateEvaluator)(nil)
+	_ OutgoingMessage = (*CloseEvaluator)(nil)
+	_ OutgoingMessage = (*Evaluate)(nil)
+	_ OutgoingMessage = (*ReadResourceResponse)(nil)
+	_ OutgoingMessage = (*ReadModuleResponse)(nil)
+	_ OutgoingMessage = (*ListResourcesResponse)(nil)
+	_ OutgoingMessage = (*ListModulesResponse)(nil)
+)
 
 func packMessage(msg OutgoingMessage, code int) ([]byte, error) {
 	enc := msgpack.NewEncoder(nil)

--- a/pkl/project_test.go
+++ b/pkl/project_test.go
@@ -88,7 +88,7 @@ package {
 `
 
 func writeFile(t *testing.T, filename string, contents string) {
-	if err := os.WriteFile(filename, []byte(contents), 0777); err != nil {
+	if err := os.WriteFile(filename, []byte(contents), 0o777); err != nil {
 		t.Logf("Failed to write file %s: %s", filename, err)
 		t.FailNow()
 	}
@@ -96,8 +96,8 @@ func writeFile(t *testing.T, filename string, contents string) {
 
 func TestLoadProject(t *testing.T) {
 	tempDir := t.TempDir()
-	_ = os.Mkdir(tempDir+"/hawks", 0777)
-	_ = os.Mkdir(tempDir+"/storks", 0777)
+	_ = os.Mkdir(tempDir+"/hawks", 0o777)
+	_ = os.Mkdir(tempDir+"/storks", 0o777)
 	writeFile(t, tempDir+"/hawks/PklProject", project1Contents)
 	writeFile(t, tempDir+"/storks/PklProject", project2Contents)
 	project, err := pkl.LoadProject(context.Background(), tempDir+"/hawks/PklProject")

--- a/pkl/unmarshal_test.go
+++ b/pkl/unmarshal_test.go
@@ -85,7 +85,7 @@ var unknownType []byte
 
 func TestUnmarshall_Primitives(t *testing.T) {
 	var res primitives.Primitives
-	var expected = primitives.Primitives{
+	expected := primitives.Primitives{
 		Res0:  "bar",
 		Res1:  1,
 		Res2:  2,


### PR DESCRIPTION
This revision implements two key changes across numerous modules: harmonizing variable declaration format to utilize var blocks for improved consistency and readability, and shifting file permission syntax from decimal (i.e., 0666) to octal (i.e., 0o666) in os.WriteFile and os.Mkdir functions for greater clarity.