### PR TITLE
Fix relative project dir paths.

### DIFF
--- a/cmd/pkl-gen-go/generatorsettings/GeneratorSettings.pkl.go
+++ b/cmd/pkl-gen-go/generatorsettings/GeneratorSettings.pkl.go
@@ -78,6 +78,12 @@ type GeneratorSettings struct {
 
 	// The URI of this module, used to resolve [projectDir].
 	Uri string `pkl:"uri"`
+
+	// Generator settings path
+	GeneratorSettingsPath *string `pkl:"settingsPath"`
+
+	// The current working directory.
+	Cwd string `pkl:"cwd"`
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a GeneratorSettings


### PR DESCRIPTION
Addresses https://github.com/apple/pkl-go/issues/48

Because of generator settings may fall back to default value (when installed globally) we can not rely on this value when building path from relative project dir.

This commit changes the behaviour of it:
1) When `generator-settings.pkl` is not present or is in default location (CWD) -> project dir is built from CWD, not settings dir
2) When settings path is overriden -> project dir is built from settings path, to ensure relative `projectDir` defined in the settings files accurately describe location.