### PR TITLE
Add a newline after license comments to stop rendering with `go doc`

### DIFF
--- a/cmd/internal/add-license-header/add-license-header.go
+++ b/cmd/internal/add-license-header/add-license-header.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package main
 
 import (
@@ -74,7 +75,12 @@ func main() {
 		if strings.HasPrefix(contentsStr, "// Code generated from") {
 			continue
 		}
-		newContents := licenseHeader + contentsStr
+		var newContents string
+		if strings.HasSuffix(file, ".go") {
+			newContents = licenseHeader + "\n" + contentsStr
+		} else {
+			newContents = licenseHeader + contentsStr
+		}
 		if err = os.WriteFile(absolutePath, []byte(newContents), 0o644); err != nil {
 			panic(err)
 		}

--- a/cmd/internal/gen-fixtures/gen-fixtures.go
+++ b/cmd/internal/gen-fixtures/gen-fixtures.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package main
 
 import (

--- a/cmd/internal/gen-snippets/gen-snippets.go
+++ b/cmd/internal/gen-snippets/gen-snippets.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package main
 
 import (

--- a/cmd/pkl-gen-go/pkg/generate.go
+++ b/cmd/pkl-gen-go/pkg/generate.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkg
 
 import (

--- a/cmd/pkl-gen-go/pkl-gen-go.go
+++ b/cmd/pkl-gen-go/pkl-gen-go.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package main
 
 import (

--- a/pkl/atomic.go
+++ b/pkl/atomic.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/decode_map.go
+++ b/pkl/decode_map.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/decode_primitives.go
+++ b/pkl/decode_primitives.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/decode_slice.go
+++ b/pkl/decode_slice.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/decode_struct.go
+++ b/pkl/decode_struct.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/decoder.go
+++ b/pkl/decoder.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/errors.go
+++ b/pkl/errors.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/evaluator.go
+++ b/pkl/evaluator.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/evaluator_exec.go
+++ b/pkl/evaluator_exec.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import "context"

--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/evaluator_manager_exec.go
+++ b/pkl/evaluator_manager_exec.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/evaluator_manager_test.go
+++ b/pkl/evaluator_manager_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/evaluator_test.go
+++ b/pkl/evaluator_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/fs_reader.go
+++ b/pkl/fs_reader.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/internal/debug.go
+++ b/pkl/internal/debug.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package internal
 
 import (

--- a/pkl/internal/msgapi/code.go
+++ b/pkl/internal/msgapi/code.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package msgapi
 
 const (

--- a/pkl/internal/msgapi/incoming.go
+++ b/pkl/internal/msgapi/incoming.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package msgapi
 
 import (

--- a/pkl/internal/msgapi/outgoing.go
+++ b/pkl/internal/msgapi/outgoing.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package msgapi
 
 import (

--- a/pkl/logger.go
+++ b/pkl/logger.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/module_source.go
+++ b/pkl/module_source.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/module_source_test.go
+++ b/pkl/module_source_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/reader.go
+++ b/pkl/reader.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/reader_test.go
+++ b/pkl/reader_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/schema.go
+++ b/pkl/schema.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import "reflect"

--- a/pkl/test_fixtures/any.pkl
+++ b/pkl/test_fixtures/any.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/any" }
 module any
 

--- a/pkl/test_fixtures/classes.pkl
+++ b/pkl/test_fixtures/classes.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/classes" }
 module classes
 

--- a/pkl/test_fixtures/collections.pkl
+++ b/pkl/test_fixtures/collections.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/collections" }
 module collections
 

--- a/pkl/test_fixtures/datasize.pkl
+++ b/pkl/test_fixtures/datasize.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/datasize" }
 module datasize
 

--- a/pkl/test_fixtures/duration.pkl
+++ b/pkl/test_fixtures/duration.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/duration" }
 module duration
 

--- a/pkl/test_fixtures/dynamic.pkl
+++ b/pkl/test_fixtures/dynamic.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/dynamic" }
 module dynamic
 

--- a/pkl/test_fixtures/nullables.pkl
+++ b/pkl/test_fixtures/nullables.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/nullables" }
 module nullables
 

--- a/pkl/test_fixtures/primitives.pkl
+++ b/pkl/test_fixtures/primitives.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/primitives" }
 module primitives
 

--- a/pkl/test_fixtures/testfs/person.pkl
+++ b/pkl/test_fixtures/testfs/person.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 name: String = "Barney"
 
 age: Int = 43

--- a/pkl/test_fixtures/testfs/subdir/person.pkl
+++ b/pkl/test_fixtures/testfs/subdir/person.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 amends "..."
 
 name = "Fred"

--- a/pkl/test_fixtures/unions.pkl
+++ b/pkl/test_fixtures/unions.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/unions" }
 module unions
 

--- a/pkl/test_fixtures/unknown_type.pkl
+++ b/pkl/test_fixtures/unknown_type.pkl
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 @go.Package { name = "github.com/apple/pkl-go/pkl/test_fixtures/gen/unknown_type" }
 module unknown_type
 

--- a/pkl/unmarshal.go
+++ b/pkl/unmarshal.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/unmarshal_test.go
+++ b/pkl/unmarshal_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl_test
 
 import (

--- a/pkl/values.go
+++ b/pkl/values.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (

--- a/pkl/values_test.go
+++ b/pkl/values_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
+
 package pkl
 
 import (


### PR DESCRIPTION
The license comments are being rendered as part of `go doc` to https://pkg.go.dev/github.com/apple/pkl-go/pkl

By adding a new line between the `package` directive and the license comments, these lines stop rendering.

Before
------

```
❯ go doc -all pkl | wc -l
    1077
```

After
-----

```
❯ go doc -all pkl | wc -l
     793
```