### PR TITLE
Refactor error handling in decode_struct.go

### DIFF
--- a/pkl/decode_struct.go
+++ b/pkl/decode_struct.go
@@ -228,10 +228,8 @@ func (d *decoder) decodePair(typ reflect.Type) (*reflect.Value, error) {
 	}
 	secondField, exists := typ.FieldByName("Second")
 	if !exists {
-		if !exists {
-			return nil, &InternalError{
-				err: errors.New("unable to find field `Second` on pkl.Pair"),
-			}
+		return nil, &InternalError{
+			err: errors.New("unable to find field `Second` on pkl.Pair"),
 		}
 	}
 	second, err := d.Decode(secondField.Type)


### PR DESCRIPTION
This commit simplifies the error handling process within the decode_struct.go file. It removes an unnecessary nested conditional check around the existence of the 'Second' field, streamlining the code for better readability and efficiency.