### PR TITLE
`pkl-gen-go` allows defining the `--cache-dir` on the Pkl evaluator

### DIFF
--- a/cmd/pkl-gen-go/generatorsettings/GeneratorSettings.pkl.go
+++ b/cmd/pkl-gen-go/generatorsettings/GeneratorSettings.pkl.go
@@ -73,6 +73,11 @@ type GeneratorSettings struct {
 	// Relative paths are resolved against the enclosing file.
 	ProjectDir *string `pkl:"projectDir"`
 
+	// The cache directory for storing packages.
+	//
+	// This corresponds to the `--cache-dir` flag in the Pkl CLI.
+	CacheDir *string `pkl:"cacheDir"`
+
 	// Print out the names of the files that will be generated, but skip writing anything to disk.
 	DryRun bool `pkl:"dryRun"`
 

--- a/cmd/pkl-gen-go/pkl-gen-go.go
+++ b/cmd/pkl-gen-go/pkl-gen-go.go
@@ -124,6 +124,9 @@ func evaluatorOptions(opts *pkl.EvaluatorOptions) {
 	if len(settings.AllowedResources) > 0 {
 		opts.AllowedResources = settings.AllowedResources
 	}
+	if *settings.CacheDir != "" {
+		opts.CacheDir = *settings.CacheDir
+	}
 }
 
 var (
@@ -228,6 +231,7 @@ func init() {
 	var allowedResources []string
 	var dryRun bool
 	var projectDir string
+	var cacheDir string
 	flags.StringVar(&generatorSettingsPath, "generator-settings", "", "The path to a generator settings file")
 	flags.StringVar(&generateScript, "generate-script", "", "The Generate.pkl script to use")
 	flags.StringToStringVar(&mappings, "mapping", nil, "The mapping of a Pkl module name to a Go package name")
@@ -237,6 +241,7 @@ func init() {
 	flags.StringSliceVar(&allowedModules, "allowed-modules", nil, "URI patterns that determine which modules can be loaded and evaluated")
 	flags.StringSliceVar(&allowedResources, "allowed-resources", nil, "URI patterns that determine which resources can be loaded and evaluated")
 	flags.StringVar(&projectDir, "project-dir", "", "The project directory to load dependency and evaluator settings from")
+	flags.StringVar(&cacheDir, "cache-dir", "", "The cache directory for storing packages")
 	flags.BoolVar(&dryRun, "dry-run", false, "Print out the names of the files that will be generated, but don't write any files")
 	flags.BoolVar(&printVersion, "version", false, "Print the version and exit")
 	var err error
@@ -264,6 +269,9 @@ func init() {
 	}
 	if projectDir != "" {
 		settings.ProjectDir = &projectDir
+	}
+	if cacheDir != "" {
+		settings.CacheDir = &cacheDir
 	}
 	settings.DryRun = dryRun
 }

--- a/codegen/src/GeneratorSettings.pkl
+++ b/codegen/src/GeneratorSettings.pkl
@@ -88,6 +88,11 @@ allowedResources: Listing<String>
 /// Paths must use `/` as the path separator.
 projectDir: String?
 
+/// The cache directory for storing packages.
+///
+/// This corresponds to the `--cache-dir` flag in the Pkl CLI.
+cacheDir: String?
+
 /// Print out the names of the files that will be generated, but skip writing anything to disk.
 dryRun: Boolean = false
 


### PR DESCRIPTION
This is useful for cases where you don't want the evaluator in use to use the default cache directory for Pkl packages.