### PR TITLE
Add a `nil` check on `settings.CacheDir`

### DIFF
--- a/cmd/pkl-gen-go/pkl-gen-go.go
+++ b/cmd/pkl-gen-go/pkl-gen-go.go
@@ -123,7 +123,7 @@ func evaluatorOptions(opts *pkl.EvaluatorOptions) {
 	if len(settings.AllowedResources) > 0 {
 		opts.AllowedResources = settings.AllowedResources
 	}
-	if *settings.CacheDir != "" {
+	if settings.CacheDir != nil && *settings.CacheDir != "" {
 		opts.CacheDir = *settings.CacheDir
 	}
 }


### PR DESCRIPTION
Otherwise we'll see the following error when it's not set:

```
invalid memory address or nil pointer dereference
```

Follow up to #59.