### PR TITLE
Use cacheDir from CLI flags in loading of `generator-settings.pkl`

### DIFF
--- a/cmd/pkl-gen-go/pkl-gen-go.go
+++ b/cmd/pkl-gen-go/pkl-gen-go.go
@@ -189,14 +189,19 @@ func findProjectDir(projectDirFlag string) string {
 
 // Loads the settings for controlling codegen.
 // Uses a Pkl evaluator that is separate from what's used for actually running codegen.
-func loadGeneratorSettings(generatorSettingsPath string, projectDirFlag string) (*generatorsettings.GeneratorSettings, error) {
+func loadGeneratorSettings(generatorSettingsPath string, projectDirFlag string, cacheDirFlag string) (*generatorsettings.GeneratorSettings, error) {
 	projectDir := findProjectDir(projectDirFlag)
 	var evaluator pkl.Evaluator
 	var err error
+	opts := func(opts *pkl.EvaluatorOptions) {
+		if cacheDirFlag != "" {
+			opts.CacheDir = cacheDirFlag
+		}
+	}
 	if projectDir != "" {
-		evaluator, err = pkl.NewProjectEvaluator(context.Background(), projectDir, pkl.PreconfiguredOptions)
+		evaluator, err = pkl.NewProjectEvaluator(context.Background(), projectDir, pkl.PreconfiguredOptions, opts)
 	} else {
-		evaluator, err = pkl.NewEvaluator(context.Background(), pkl.PreconfiguredOptions)
+		evaluator, err = pkl.NewEvaluator(context.Background(), pkl.PreconfiguredOptions, opts)
 	}
 	if err != nil {
 		panic(err)
@@ -258,7 +263,7 @@ func init() {
 			panic(err)
 		}
 	}
-	settings, err = loadGeneratorSettings(generatorSettingsPath, projectDir)
+	settings, err = loadGeneratorSettings(generatorSettingsPath, projectDir, cacheDir)
 	if err != nil {
 		panic(err)
 	}

--- a/pkl/evaluator_exec.go
+++ b/pkl/evaluator_exec.go
@@ -51,7 +51,7 @@ func NewProjectEvaluator(ctx context.Context, projectDir string, opts ...func(op
 // because it lessens the overhead of each successive evaluator.
 func NewProjectEvaluatorWithCommand(ctx context.Context, projectDir string, pklCmd []string, opts ...func(options *EvaluatorOptions)) (Evaluator, error) {
 	manager := NewEvaluatorManagerWithCommand(pklCmd)
-	projectEvaluator, err := manager.NewEvaluator(ctx, PreconfiguredOptions)
+	projectEvaluator, err := manager.NewEvaluator(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -142,7 +142,7 @@ func (m *evaluatorManager) NewEvaluator(ctx context.Context, opts ...func(option
 }
 
 func (m *evaluatorManager) NewProjectEvaluator(ctx context.Context, projectDir string, opts ...func(options *EvaluatorOptions)) (Evaluator, error) {
-	projectEvaluator, err := NewEvaluator(ctx, PreconfiguredOptions)
+	projectEvaluator, err := NewEvaluator(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
By defaulting to `PreconfiguredOptions`, we ignore `--cache-dir` and friends, making vendoring impossible.

This PR is *just* the quick patch to solve the immediate problem and _not_ any further cleanup, so as not to give #56 a difficult rebase.