### PR TITLE
Concrete structs

### DIFF
--- a/codegen/snippet-tests/output/bugholder/B.pkl.go
+++ b/codegen/snippet-tests/output/bugholder/B.pkl.go
@@ -7,7 +7,7 @@ type B interface {
 	GetB() string
 }
 
-var _ B = (*BImpl)(nil)
+var _ B = BImpl{}
 
 type BImpl struct {
 	B string `pkl:"b"`
@@ -15,10 +15,10 @@ type BImpl struct {
 	A string `pkl:"a"`
 }
 
-func (rcv *BImpl) GetB() string {
+func (rcv BImpl) GetB() string {
 	return rcv.B
 }
 
-func (rcv *BImpl) GetA() string {
+func (rcv BImpl) GetA() string {
 	return rcv.A
 }

--- a/codegen/snippet-tests/output/bugholder/Bike.pkl.go
+++ b/codegen/snippet-tests/output/bugholder/Bike.pkl.go
@@ -7,5 +7,5 @@ type Bike struct {
 	// Wheels are the front and back wheels.
 	//
 	// There are typically two of them.
-	Wheels []*Wheel `pkl:"wheels"`
+	Wheels []Wheel `pkl:"wheels"`
 }

--- a/codegen/snippet-tests/output/bugholder/BugHolder.pkl.go
+++ b/codegen/snippet-tests/output/bugholder/BugHolder.pkl.go
@@ -8,9 +8,9 @@ import (
 )
 
 type BugHolder struct {
-	Bug *Bug `pkl:"bug"`
+	Bug Bug `pkl:"bug"`
 
-	N蚊子 *Bug `pkl:"蚊子"`
+	N蚊子 Bug `pkl:"蚊子"`
 
 	ThisPerson ThisPerson `pkl:"thisPerson"`
 
@@ -18,10 +18,10 @@ type BugHolder struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a BugHolder
-func LoadFromPath(ctx context.Context, path string) (ret *BugHolder, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret BugHolder, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return BugHolder{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -34,10 +34,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *BugHolder, err error) 
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a BugHolder
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*BugHolder, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (BugHolder, error) {
 	var ret BugHolder
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return BugHolder{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/bugholder/C.pkl.go
+++ b/codegen/snippet-tests/output/bugholder/C.pkl.go
@@ -7,14 +7,14 @@ type C interface {
 	GetC() string
 }
 
-var _ C = (*CImpl)(nil)
+var _ C = CImpl{}
 
 type CImpl struct {
-	*BImpl
+	BImpl
 
 	C string `pkl:"c"`
 }
 
-func (rcv *CImpl) GetC() string {
+func (rcv CImpl) GetC() string {
 	return rcv.C
 }

--- a/codegen/snippet-tests/output/bugholder/D.pkl.go
+++ b/codegen/snippet-tests/output/bugholder/D.pkl.go
@@ -7,14 +7,14 @@ type D interface {
 	GetD() string
 }
 
-var _ D = (*DImpl)(nil)
+var _ D = DImpl{}
 
 type DImpl struct {
-	*CImpl
+	CImpl
 
 	D string `pkl:"d"`
 }
 
-func (rcv *DImpl) GetD() string {
+func (rcv DImpl) GetD() string {
 	return rcv.D
 }

--- a/codegen/snippet-tests/output/bugholder/Person.pkl.go
+++ b/codegen/snippet-tests/output/bugholder/Person.pkl.go
@@ -4,7 +4,7 @@ package bugholder
 type Person interface {
 	Being
 
-	GetBike() *Bike
+	GetBike() Bike
 
 	GetFirstName() *uint16
 
@@ -13,13 +13,13 @@ type Person interface {
 	GetThings() map[int]struct{}
 }
 
-var _ Person = (*PersonImpl)(nil)
+var _ Person = PersonImpl{}
 
 // A Person!
 type PersonImpl struct {
 	IsAlive bool `pkl:"isAlive"`
 
-	Bike *Bike `pkl:"bike"`
+	Bike Bike `pkl:"bike"`
 
 	// The person's first name
 	FirstName *uint16 `pkl:"firstName"`
@@ -30,24 +30,24 @@ type PersonImpl struct {
 	Things map[int]struct{} `pkl:"things"`
 }
 
-func (rcv *PersonImpl) GetIsAlive() bool {
+func (rcv PersonImpl) GetIsAlive() bool {
 	return rcv.IsAlive
 }
 
-func (rcv *PersonImpl) GetBike() *Bike {
+func (rcv PersonImpl) GetBike() Bike {
 	return rcv.Bike
 }
 
 // The person's first name
-func (rcv *PersonImpl) GetFirstName() *uint16 {
+func (rcv PersonImpl) GetFirstName() *uint16 {
 	return rcv.FirstName
 }
 
 // The person's last name
-func (rcv *PersonImpl) GetLastName() map[string]*uint32 {
+func (rcv PersonImpl) GetLastName() map[string]*uint32 {
 	return rcv.LastName
 }
 
-func (rcv *PersonImpl) GetThings() map[int]struct{} {
+func (rcv PersonImpl) GetThings() map[int]struct{} {
 	return rcv.Things
 }

--- a/codegen/snippet-tests/output/bugholder/ThisPerson.pkl.go
+++ b/codegen/snippet-tests/output/bugholder/ThisPerson.pkl.go
@@ -4,25 +4,25 @@ package bugholder
 type ThisPerson interface {
 	Person
 
-	GetMyself() ThisPerson
+	GetMyself() *ThisPerson
 
 	GetSomeoneElse() Person
 }
 
-var _ ThisPerson = (*ThisPersonImpl)(nil)
+var _ ThisPerson = ThisPersonImpl{}
 
 type ThisPersonImpl struct {
-	*PersonImpl
+	PersonImpl
 
-	Myself ThisPerson `pkl:"myself"`
+	Myself *ThisPerson `pkl:"myself"`
 
 	SomeoneElse Person `pkl:"someoneElse"`
 }
 
-func (rcv *ThisPersonImpl) GetMyself() ThisPerson {
+func (rcv ThisPersonImpl) GetMyself() *ThisPerson {
 	return rcv.Myself
 }
 
-func (rcv *ThisPersonImpl) GetSomeoneElse() Person {
+func (rcv ThisPersonImpl) GetSomeoneElse() Person {
 	return rcv.SomeoneElse
 }

--- a/codegen/snippet-tests/output/cyclicmodule/CyclicModule.pkl.go
+++ b/codegen/snippet-tests/output/cyclicmodule/CyclicModule.pkl.go
@@ -8,14 +8,14 @@ import (
 )
 
 type CyclicModule struct {
-	Thing *Cyclic `pkl:"thing"`
+	Thing Cyclic `pkl:"thing"`
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a CyclicModule
-func LoadFromPath(ctx context.Context, path string) (ret *CyclicModule, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret CyclicModule, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return CyclicModule{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -28,10 +28,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *CyclicModule, err erro
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a CyclicModule
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*CyclicModule, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (CyclicModule, error) {
 	var ret CyclicModule
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return CyclicModule{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/emptyopenmodule/EmptyOpenModule.pkl.go
+++ b/codegen/snippet-tests/output/emptyopenmodule/EmptyOpenModule.pkl.go
@@ -10,16 +10,16 @@ import (
 type EmptyOpenModule interface {
 }
 
-var _ EmptyOpenModule = (*EmptyOpenModuleImpl)(nil)
+var _ EmptyOpenModule = EmptyOpenModuleImpl{}
 
 type EmptyOpenModuleImpl struct {
 }
 
-// LoadFromPath loads the pkl module at the given path and evaluates it into a EmptyOpenModule
-func LoadFromPath(ctx context.Context, path string) (ret EmptyOpenModule, err error) {
+// LoadFromPath loads the pkl module at the given path and evaluates it into a EmptyOpenModuleImpl
+func LoadFromPath(ctx context.Context, path string) (ret EmptyOpenModuleImpl, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return EmptyOpenModuleImpl{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -31,11 +31,11 @@ func LoadFromPath(ctx context.Context, path string) (ret EmptyOpenModule, err er
 	return ret, err
 }
 
-// Load loads the pkl module at the given source and evaluates it with the given evaluator into a EmptyOpenModule
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (EmptyOpenModule, error) {
+// Load loads the pkl module at the given source and evaluates it with the given evaluator into a EmptyOpenModuleImpl
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (EmptyOpenModuleImpl, error) {
 	var ret EmptyOpenModuleImpl
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return EmptyOpenModuleImpl{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/explicitname/ExplicitlyCoolName.pkl.go
+++ b/codegen/snippet-tests/output/explicitname/ExplicitlyCoolName.pkl.go
@@ -8,14 +8,14 @@ import (
 )
 
 type ExplicitlyCoolName struct {
-	MyCoolProp *SomethingVeryFunny `pkl:"myProp"`
+	MyCoolProp SomethingVeryFunny `pkl:"myProp"`
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a ExplicitlyCoolName
-func LoadFromPath(ctx context.Context, path string) (ret *ExplicitlyCoolName, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret ExplicitlyCoolName, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return ExplicitlyCoolName{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -28,10 +28,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *ExplicitlyCoolName, er
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a ExplicitlyCoolName
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*ExplicitlyCoolName, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (ExplicitlyCoolName, error) {
 	var ret ExplicitlyCoolName
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return ExplicitlyCoolName{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/extendabstractclass/B.pkl.go
+++ b/codegen/snippet-tests/output/extendabstractclass/B.pkl.go
@@ -7,7 +7,7 @@ type B interface {
 	GetC() string
 }
 
-var _ B = (*BImpl)(nil)
+var _ B = BImpl{}
 
 type BImpl struct {
 	B string `pkl:"b"`
@@ -15,10 +15,10 @@ type BImpl struct {
 	C string `pkl:"c"`
 }
 
-func (rcv *BImpl) GetB() string {
+func (rcv BImpl) GetB() string {
 	return rcv.B
 }
 
-func (rcv *BImpl) GetC() string {
+func (rcv BImpl) GetC() string {
 	return rcv.C
 }

--- a/codegen/snippet-tests/output/extendabstractclass/ExtendsAbstractClass.pkl.go
+++ b/codegen/snippet-tests/output/extendabstractclass/ExtendsAbstractClass.pkl.go
@@ -12,10 +12,10 @@ type ExtendsAbstractClass struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a ExtendsAbstractClass
-func LoadFromPath(ctx context.Context, path string) (ret *ExtendsAbstractClass, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret ExtendsAbstractClass, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return ExtendsAbstractClass{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -28,10 +28,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *ExtendsAbstractClass, 
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a ExtendsAbstractClass
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*ExtendsAbstractClass, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (ExtendsAbstractClass, error) {
 	var ret ExtendsAbstractClass
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return ExtendsAbstractClass{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/extendmodule/ExtendModule.pkl.go
+++ b/codegen/snippet-tests/output/extendmodule/ExtendModule.pkl.go
@@ -14,23 +14,23 @@ type ExtendModule interface {
 	GetBar() string
 }
 
-var _ ExtendModule = (*ExtendModuleImpl)(nil)
+var _ ExtendModule = ExtendModuleImpl{}
 
 type ExtendModuleImpl struct {
-	*openmodule.MyModuleImpl
+	openmodule.MyModuleImpl
 
 	Bar string `pkl:"bar"`
 }
 
-func (rcv *ExtendModuleImpl) GetBar() string {
+func (rcv ExtendModuleImpl) GetBar() string {
 	return rcv.Bar
 }
 
-// LoadFromPath loads the pkl module at the given path and evaluates it into a ExtendModule
-func LoadFromPath(ctx context.Context, path string) (ret ExtendModule, err error) {
+// LoadFromPath loads the pkl module at the given path and evaluates it into a ExtendModuleImpl
+func LoadFromPath(ctx context.Context, path string) (ret ExtendModuleImpl, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return ExtendModuleImpl{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -42,11 +42,11 @@ func LoadFromPath(ctx context.Context, path string) (ret ExtendModule, err error
 	return ret, err
 }
 
-// Load loads the pkl module at the given source and evaluates it with the given evaluator into a ExtendModule
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (ExtendModule, error) {
+// Load loads the pkl module at the given source and evaluates it with the given evaluator into a ExtendModuleImpl
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (ExtendModuleImpl, error) {
 	var ret ExtendModuleImpl
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return ExtendModuleImpl{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/extendopenclass/ExtendingOpenClass.pkl.go
+++ b/codegen/snippet-tests/output/extendopenclass/ExtendingOpenClass.pkl.go
@@ -14,10 +14,10 @@ type ExtendingOpenClass struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a ExtendingOpenClass
-func LoadFromPath(ctx context.Context, path string) (ret *ExtendingOpenClass, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret ExtendingOpenClass, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return ExtendingOpenClass{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -30,10 +30,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *ExtendingOpenClass, er
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a ExtendingOpenClass
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*ExtendingOpenClass, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (ExtendingOpenClass, error) {
 	var ret ExtendingOpenClass
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return ExtendingOpenClass{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/extendopenclass/MyClass.pkl.go
+++ b/codegen/snippet-tests/output/extendopenclass/MyClass.pkl.go
@@ -7,14 +7,14 @@ type MyClass interface {
 	GetMyBoolean() bool
 }
 
-var _ MyClass = (*MyClassImpl)(nil)
+var _ MyClass = MyClassImpl{}
 
 type MyClassImpl struct {
-	*MyOpenClassImpl
+	MyOpenClassImpl
 
 	MyBoolean bool `pkl:"myBoolean"`
 }
 
-func (rcv *MyClassImpl) GetMyBoolean() bool {
+func (rcv MyClassImpl) GetMyBoolean() bool {
 	return rcv.MyBoolean
 }

--- a/codegen/snippet-tests/output/extendopenclass/MyClass2.pkl.go
+++ b/codegen/snippet-tests/output/extendopenclass/MyClass2.pkl.go
@@ -9,14 +9,14 @@ type MyClass2 interface {
 	GetMyBoolean() bool
 }
 
-var _ MyClass2 = (*MyClass2Impl)(nil)
+var _ MyClass2 = MyClass2Impl{}
 
 type MyClass2Impl struct {
-	*lib3.GoGoGoImpl
+	lib3.GoGoGoImpl
 
 	MyBoolean bool `pkl:"myBoolean"`
 }
 
-func (rcv *MyClass2Impl) GetMyBoolean() bool {
+func (rcv MyClass2Impl) GetMyBoolean() bool {
 	return rcv.MyBoolean
 }

--- a/codegen/snippet-tests/output/extendopenclass/MyOpenClass.pkl.go
+++ b/codegen/snippet-tests/output/extendopenclass/MyOpenClass.pkl.go
@@ -5,12 +5,12 @@ type MyOpenClass interface {
 	GetMyStr() string
 }
 
-var _ MyOpenClass = (*MyOpenClassImpl)(nil)
+var _ MyOpenClass = MyOpenClassImpl{}
 
 type MyOpenClassImpl struct {
 	MyStr string `pkl:"myStr"`
 }
 
-func (rcv *MyOpenClassImpl) GetMyStr() string {
+func (rcv MyOpenClassImpl) GetMyStr() string {
 	return rcv.MyStr
 }

--- a/codegen/snippet-tests/output/hiddenproperties/HiddenProperties.pkl.go
+++ b/codegen/snippet-tests/output/hiddenproperties/HiddenProperties.pkl.go
@@ -12,10 +12,10 @@ type HiddenProperties struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a HiddenProperties
-func LoadFromPath(ctx context.Context, path string) (ret *HiddenProperties, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret HiddenProperties, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return HiddenProperties{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -28,10 +28,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *HiddenProperties, err 
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a HiddenProperties
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*HiddenProperties, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (HiddenProperties, error) {
 	var ret HiddenProperties
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return HiddenProperties{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/moduletype/ModuleType.pkl.go
+++ b/codegen/snippet-tests/output/moduletype/ModuleType.pkl.go
@@ -13,16 +13,16 @@ type ModuleType struct {
 
 	Foo *ModuleType `pkl:"foo"`
 
-	Lib *lib4.MyLib4 `pkl:"lib"`
+	Lib lib4.MyLib4 `pkl:"lib"`
 
 	FooAgain *ModuleType `pkl:"fooAgain"`
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a ModuleType
-func LoadFromPath(ctx context.Context, path string) (ret *ModuleType, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret ModuleType, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return ModuleType{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -35,10 +35,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *ModuleType, err error)
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a ModuleType
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*ModuleType, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (ModuleType, error) {
 	var ret ModuleType
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return ModuleType{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/moduleusinglib/ModuleUsingLib.pkl.go
+++ b/codegen/snippet-tests/output/moduleusinglib/ModuleUsingLib.pkl.go
@@ -21,10 +21,10 @@ type ModuleUsingLib struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a ModuleUsingLib
-func LoadFromPath(ctx context.Context, path string) (ret *ModuleUsingLib, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret ModuleUsingLib, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return ModuleUsingLib{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -37,10 +37,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *ModuleUsingLib, err er
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a ModuleUsingLib
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*ModuleUsingLib, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (ModuleUsingLib, error) {
 	var ret ModuleUsingLib
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return ModuleUsingLib{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/override/Bar.pkl.go
+++ b/codegen/snippet-tests/output/override/Bar.pkl.go
@@ -5,12 +5,12 @@ type Bar interface {
 	Foo
 }
 
-var _ Bar = (*BarImpl)(nil)
+var _ Bar = BarImpl{}
 
 type BarImpl struct {
 	MyProp string `pkl:"myProp"`
 }
 
-func (rcv *BarImpl) GetMyProp() string {
+func (rcv BarImpl) GetMyProp() string {
 	return rcv.MyProp
 }

--- a/codegen/snippet-tests/output/override/Override.pkl.go
+++ b/codegen/snippet-tests/output/override/Override.pkl.go
@@ -12,10 +12,10 @@ type Override struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Override
-func LoadFromPath(ctx context.Context, path string) (ret *Override, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Override, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Override{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -28,10 +28,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Override, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Override
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Override, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Override, error) {
 	var ret Override
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Override{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/override2/MySubclass.pkl.go
+++ b/codegen/snippet-tests/output/override2/MySubclass.pkl.go
@@ -7,16 +7,16 @@ type MySubclass interface {
 	GetFoo() string
 }
 
-var _ MySubclass = (*MySubclassImpl)(nil)
+var _ MySubclass = MySubclassImpl{}
 
 type MySubclassImpl struct {
-	*Override2Impl
+	Override2Impl
 
 	// Different doc comments
 	Foo string `pkl:"foo"`
 }
 
 // Different doc comments
-func (rcv *MySubclassImpl) GetFoo() string {
+func (rcv MySubclassImpl) GetFoo() string {
 	return rcv.Foo
 }

--- a/codegen/snippet-tests/output/override2/Override2.pkl.go
+++ b/codegen/snippet-tests/output/override2/Override2.pkl.go
@@ -11,7 +11,7 @@ type Override2 interface {
 	GetFoo() string
 }
 
-var _ Override2 = (*Override2Impl)(nil)
+var _ Override2 = Override2Impl{}
 
 type Override2Impl struct {
 	// Doc comments
@@ -19,15 +19,15 @@ type Override2Impl struct {
 }
 
 // Doc comments
-func (rcv *Override2Impl) GetFoo() string {
+func (rcv Override2Impl) GetFoo() string {
 	return rcv.Foo
 }
 
-// LoadFromPath loads the pkl module at the given path and evaluates it into a Override2
-func LoadFromPath(ctx context.Context, path string) (ret Override2, err error) {
+// LoadFromPath loads the pkl module at the given path and evaluates it into a Override2Impl
+func LoadFromPath(ctx context.Context, path string) (ret Override2Impl, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Override2Impl{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -39,11 +39,11 @@ func LoadFromPath(ctx context.Context, path string) (ret Override2, err error) {
 	return ret, err
 }
 
-// Load loads the pkl module at the given source and evaluates it with the given evaluator into a Override2
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Override2, error) {
+// Load loads the pkl module at the given source and evaluates it with the given evaluator into a Override2Impl
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Override2Impl, error) {
 	var ret Override2Impl
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Override2Impl{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/structtags/StructTags.pkl.go
+++ b/codegen/snippet-tests/output/structtags/StructTags.pkl.go
@@ -32,10 +32,10 @@ type StructTags struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a StructTags
-func LoadFromPath(ctx context.Context, path string) (ret *StructTags, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret StructTags, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return StructTags{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -48,10 +48,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *StructTags, err error)
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a StructTags
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*StructTags, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (StructTags, error) {
 	var ret StructTags
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return StructTags{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/support/lib/Lib.pkl.go
+++ b/codegen/snippet-tests/output/support/lib/Lib.pkl.go
@@ -11,10 +11,10 @@ type Lib struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Lib
-func LoadFromPath(ctx context.Context, path string) (ret *Lib, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Lib, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Lib{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -27,10 +27,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Lib, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Lib
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Lib, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Lib, error) {
 	var ret Lib
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Lib{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/support/lib/MyClass.pkl.go
+++ b/codegen/snippet-tests/output/support/lib/MyClass.pkl.go
@@ -5,12 +5,12 @@ type MyClass interface {
 	GetThing() string
 }
 
-var _ MyClass = (*MyClassImpl)(nil)
+var _ MyClass = MyClassImpl{}
 
 type MyClassImpl struct {
 	Thing string `pkl:"thing"`
 }
 
-func (rcv *MyClassImpl) GetThing() string {
+func (rcv MyClassImpl) GetThing() string {
 	return rcv.Thing
 }

--- a/codegen/snippet-tests/output/support/lib3/GoGoGo.pkl.go
+++ b/codegen/snippet-tests/output/support/lib3/GoGoGo.pkl.go
@@ -5,12 +5,12 @@ type GoGoGo interface {
 	GetDuck() string
 }
 
-var _ GoGoGo = (*GoGoGoImpl)(nil)
+var _ GoGoGo = GoGoGoImpl{}
 
 type GoGoGoImpl struct {
 	Duck string `pkl:"duck"`
 }
 
-func (rcv *GoGoGoImpl) GetDuck() string {
+func (rcv GoGoGoImpl) GetDuck() string {
 	return rcv.Duck
 }

--- a/codegen/snippet-tests/output/support/lib3/Lib3.pkl.go
+++ b/codegen/snippet-tests/output/support/lib3/Lib3.pkl.go
@@ -11,10 +11,10 @@ type Lib3 struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Lib3
-func LoadFromPath(ctx context.Context, path string) (ret *Lib3, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Lib3, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Lib3{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -27,10 +27,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Lib3, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Lib3
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Lib3, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Lib3, error) {
 	var ret Lib3
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Lib3{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/support/lib4/Lib4.pkl.go
+++ b/codegen/snippet-tests/output/support/lib4/Lib4.pkl.go
@@ -12,10 +12,10 @@ type Lib4 struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Lib4
-func LoadFromPath(ctx context.Context, path string) (ret *Lib4, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Lib4, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Lib4{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -28,10 +28,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Lib4, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Lib4
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Lib4, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Lib4, error) {
 	var ret Lib4
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Lib4{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/support/lib4/MyLib4.pkl.go
+++ b/codegen/snippet-tests/output/support/lib4/MyLib4.pkl.go
@@ -2,5 +2,5 @@
 package lib4
 
 type MyLib4 struct {
-	Foo *Lib4 `pkl:"foo"`
+	Foo Lib4 `pkl:"foo"`
 }

--- a/codegen/snippet-tests/output/support/openmodule/MyModule.pkl.go
+++ b/codegen/snippet-tests/output/support/openmodule/MyModule.pkl.go
@@ -11,21 +11,21 @@ type MyModule interface {
 	GetFoo() string
 }
 
-var _ MyModule = (*MyModuleImpl)(nil)
+var _ MyModule = MyModuleImpl{}
 
 type MyModuleImpl struct {
 	Foo string `pkl:"foo"`
 }
 
-func (rcv *MyModuleImpl) GetFoo() string {
+func (rcv MyModuleImpl) GetFoo() string {
 	return rcv.Foo
 }
 
-// LoadFromPath loads the pkl module at the given path and evaluates it into a MyModule
-func LoadFromPath(ctx context.Context, path string) (ret MyModule, err error) {
+// LoadFromPath loads the pkl module at the given path and evaluates it into a MyModuleImpl
+func LoadFromPath(ctx context.Context, path string) (ret MyModuleImpl, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return MyModuleImpl{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -37,11 +37,11 @@ func LoadFromPath(ctx context.Context, path string) (ret MyModule, err error) {
 	return ret, err
 }
 
-// Load loads the pkl module at the given source and evaluates it with the given evaluator into a MyModule
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (MyModule, error) {
+// Load loads the pkl module at the given source and evaluates it with the given evaluator into a MyModuleImpl
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (MyModuleImpl, error) {
 	var ret MyModuleImpl
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return MyModuleImpl{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/union/Union.pkl.go
+++ b/codegen/snippet-tests/output/union/Union.pkl.go
@@ -26,10 +26,10 @@ type Union struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Union
-func LoadFromPath(ctx context.Context, path string) (ret *Union, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Union, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Union{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -42,10 +42,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Union, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Union
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Union, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Union, error) {
 	var ret Union
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Union{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/snippet-tests/output/unionnamekeyword/UnionNameKeyword.pkl.go
+++ b/codegen/snippet-tests/output/unionnamekeyword/UnionNameKeyword.pkl.go
@@ -13,10 +13,10 @@ type UnionNameKeyword struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a UnionNameKeyword
-func LoadFromPath(ctx context.Context, path string) (ret *UnionNameKeyword, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret UnionNameKeyword, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return UnionNameKeyword{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -29,10 +29,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *UnionNameKeyword, err 
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a UnionNameKeyword
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*UnionNameKeyword, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (UnionNameKeyword, error) {
 	var ret UnionNameKeyword
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return UnionNameKeyword{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/codegen/src/internal/ClassGen.pkl
+++ b/codegen/src/internal/ClassGen.pkl
@@ -42,7 +42,7 @@ contents = new Listing {
     interface
     when (!isAbstract) {
       ""
-      "var _ \(classInfo.interface.name) = (\(classInfo.struct.type.render(classInfo.goPackage)))(nil)"
+      "var _ \(classInfo.interface.name) = \(classInfo.struct.type.render(classInfo.goPackage)){}"
     }
   }
   when (!isAbstract) {
@@ -55,11 +55,11 @@ contents = new Listing {
   }
   when (isModule && !isAbstract) {
     ""
-    "// LoadFromPath loads the pkl module at the given path and evaluates it into a \(classInfo.name)"
-    "func LoadFromPath(ctx context.Context, path string) (ret \(classInfo.type.render(classInfo.goPackage)), err error) {"
+    "// LoadFromPath loads the pkl module at the given path and evaluates it into a \(classInfo.struct.name)"
+    "func LoadFromPath(ctx context.Context, path string) (ret \(classInfo.struct.type.render(classInfo.goPackage)), err error) {"
     "\tevaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)"
     "\tif err != nil {"
-    "\t\treturn nil, err"
+    "\t\treturn \(classInfo.struct.type.render(classInfo.goPackage)){}, err"
     "\t}"
     "\tdefer func() {"
     "\t\tcerr := evaluator.Close()"
@@ -71,13 +71,13 @@ contents = new Listing {
     "\treturn ret, err"
     "}"
     ""
-    "// Load loads the pkl module at the given source and evaluates it with the given evaluator into a \(classInfo.name)"
-    "func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (\(classInfo.type.render(classInfo.goPackage)), error) {"
+    "// Load loads the pkl module at the given source and evaluates it with the given evaluator into a \(classInfo.struct.name)"
+    "func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (\(classInfo.struct.type.render(classInfo.goPackage)), error) {"
     "\tvar ret \(classInfo.struct.name)"
     "\tif err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {"
-    "\t\treturn nil, err"
+    "\t\treturn \(classInfo.struct.name){}, err"
     "\t}"
-    "\treturn &ret, nil"
+    "\treturn ret, nil"
     "}"
   }
   ""
@@ -186,7 +186,15 @@ local struct: String = new Listing {
     when (field.docComment != null) {
       utils.renderDocComment(field.docComment!!, "\t")
     }
-    renderStructField(pklPropertyName, field)
+    when (field.type == classInfo.type) {
+      renderStructField(pklPropertyName, (field) {
+        type = new Type.Pointer {
+          elem = field.type
+        }
+      })
+    } else {
+      renderStructField(pklPropertyName, field)
+    }
   }
   "}"
 }
@@ -200,7 +208,7 @@ local interface: String? =
       new Listing {
         "type \(classInfo.interface.name) interface {"
         when (superClass != null) {
-          "\t\(superClass.type.render(classInfo.goPackage))"
+          "\t\(superClass.interface.type.render(classInfo.goPackage))"
           when (!methodsToGenerate.isEmpty) {
             ""
           }
@@ -209,6 +217,13 @@ local interface: String? =
           when (key != methodsToGenerate.keys.first) {
             ""
           }
+          let (field = if (field.type == classInfo.type)
+            (field) {
+              type = new Type.Pointer {
+                elem = field.type
+              }
+            } else field
+          )
           "\tGet\(field.name)() \(field.type.render(classInfo.goPackage))"
         }
         "}"
@@ -259,6 +274,13 @@ local function renderGetter(field: GoStructField): String = new Listing {
   when (field.docComment != null) {
     utils.renderDocComment(field.docComment!!, "")
   }
+  let (field = if (field.type == classInfo.type)
+      (field) {
+        type = new Type.Pointer {
+          elem = field.type
+        }
+      } else field
+  )
   "func (rcv \(classInfo.struct.type.render(classInfo.goPackage))) Get\(field.name)() \(field.type.render(classInfo.goPackage)) {"
   "\treturn rcv.\(field.name)"
   "}"

--- a/codegen/src/internal/GoMapping.pkl
+++ b/codegen/src/internal/GoMapping.pkl
@@ -95,9 +95,9 @@ class Class extends GoMapping {
       || clazz.superclass.reflectee != Typed && clazz.superclass.reflectee != Module
     )
       new Interface {
-        name = self.name
+        name = "\(self.name)"
         type = new Type.Declared {
-          typeName = self.name
+          typeName = outer.name
           importPath = self.goPackage
           package = self.goPackageShort
         }
@@ -107,18 +107,16 @@ class Class extends GoMapping {
   struct: Struct? =
     if (clazz.modifiers.contains("abstract")) null
     else
-      let (structName =  if (interface == null) name else "\(name)Impl")
+      let (structName = if (self.interface == null) name else "\(self.name)Impl")
         new Struct {
           name = structName
           clazz = self.clazz
-          type = new Type.Pointer {
-            elem = new Type.Declared {
+          type = new Type.Declared {
               typeName = structName
               importPath = self.goPackage
               package = self.goPackageShort
             }
           }
-        }
 
 }
 

--- a/codegen/src/internal/typegen.pkl
+++ b/codegen/src/internal/typegen.pkl
@@ -26,17 +26,17 @@ function generateType(
   enclosing: reflect.TypeDeclaration,
   seenMappings: List<GoMapping>
 ): Type =
-  if (type is reflect.DeclaredType)
+  if (type is reflect.NullableType)
+  let (_elem = generateType(type.member, enclosing, seenMappings))
+  // No double pointers
+    if (_elem is Type.Pointer) _elem
+    else new Type.Pointer { elem = _elem }
+  else if (type is reflect.DeclaredType)
     generateDeclaredType(type, enclosing, seenMappings)
   else if (type is reflect.ModuleType)
     let (moduleClass = enclosing.enclosingDeclaration.moduleClass)
       generateType(reflect.DeclaredType(moduleClass), moduleClass, seenMappings)
   else if (type is reflect.UnionType) generateUnionType(type, seenMappings)
-  else if (type is reflect.NullableType)
-    let (_elem = generateType(type.member, enclosing, seenMappings))
-      // No double pointers
-      if (_elem is Type.Pointer) _elem
-      else new Type.Pointer { elem = _elem }
   else if (type is reflect.UnknownType) anyType
   else if (type is reflect.NothingType) throw("Unable to generate Go for the `nothing` type")
   else if (type is reflect.StringLiteralType) new Type.Declared { typeName = "string" }

--- a/pkl/test_fixtures/gen/any/Any.pkl.go
+++ b/pkl/test_fixtures/gen/any/Any.pkl.go
@@ -16,10 +16,10 @@ type Any struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Any
-func LoadFromPath(ctx context.Context, path string) (ret *Any, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Any, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Any{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -32,10 +32,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Any, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Any
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Any, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Any, error) {
 	var ret Any
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Any{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/test_fixtures/gen/classes/Cat.pkl.go
+++ b/pkl/test_fixtures/gen/classes/Cat.pkl.go
@@ -7,7 +7,7 @@ type Cat interface {
 	GetMeows() bool
 }
 
-var _ Cat = (*CatImpl)(nil)
+var _ Cat = CatImpl{}
 
 type CatImpl struct {
 	Meows bool `pkl:"meows"`
@@ -15,10 +15,10 @@ type CatImpl struct {
 	Name string `pkl:"name"`
 }
 
-func (rcv *CatImpl) GetMeows() bool {
+func (rcv CatImpl) GetMeows() bool {
 	return rcv.Meows
 }
 
-func (rcv *CatImpl) GetName() string {
+func (rcv CatImpl) GetName() string {
 	return rcv.Name
 }

--- a/pkl/test_fixtures/gen/classes/Classes.pkl.go
+++ b/pkl/test_fixtures/gen/classes/Classes.pkl.go
@@ -12,14 +12,14 @@ type Classes struct {
 
 	MyAnimal Animal `pkl:"myAnimal"`
 
-	House *House `pkl:"house"`
+	House House `pkl:"house"`
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Classes
-func LoadFromPath(ctx context.Context, path string) (ret *Classes, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Classes, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Classes{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -32,10 +32,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Classes, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Classes
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Classes, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Classes, error) {
 	var ret Classes
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Classes{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/test_fixtures/gen/classes/Dog.pkl.go
+++ b/pkl/test_fixtures/gen/classes/Dog.pkl.go
@@ -9,7 +9,7 @@ type Dog interface {
 	GetBreed() string
 }
 
-var _ Dog = (*DogImpl)(nil)
+var _ Dog = DogImpl{}
 
 type DogImpl struct {
 	Barks bool `pkl:"barks"`
@@ -19,14 +19,14 @@ type DogImpl struct {
 	Name string `pkl:"name"`
 }
 
-func (rcv *DogImpl) GetBarks() bool {
+func (rcv DogImpl) GetBarks() bool {
 	return rcv.Barks
 }
 
-func (rcv *DogImpl) GetBreed() string {
+func (rcv DogImpl) GetBreed() string {
 	return rcv.Breed
 }
 
-func (rcv *DogImpl) GetName() string {
+func (rcv DogImpl) GetName() string {
 	return rcv.Name
 }

--- a/pkl/test_fixtures/gen/classes/Greyhound.pkl.go
+++ b/pkl/test_fixtures/gen/classes/Greyhound.pkl.go
@@ -7,14 +7,14 @@ type Greyhound interface {
 	GetCanRoach() bool
 }
 
-var _ Greyhound = (*GreyhoundImpl)(nil)
+var _ Greyhound = GreyhoundImpl{}
 
 type GreyhoundImpl struct {
-	*DogImpl
+	DogImpl
 
 	CanRoach bool `pkl:"canRoach"`
 }
 
-func (rcv *GreyhoundImpl) GetCanRoach() bool {
+func (rcv GreyhoundImpl) GetCanRoach() bool {
 	return rcv.CanRoach
 }

--- a/pkl/test_fixtures/gen/collections/Collections.pkl.go
+++ b/pkl/test_fixtures/gen/collections/Collections.pkl.go
@@ -36,10 +36,10 @@ type Collections struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Collections
-func LoadFromPath(ctx context.Context, path string) (ret *Collections, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Collections, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Collections{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -52,10 +52,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Collections, err error
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Collections
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Collections, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Collections, error) {
 	var ret Collections
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Collections{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/test_fixtures/gen/datasize/Datasize.pkl.go
+++ b/pkl/test_fixtures/gen/datasize/Datasize.pkl.go
@@ -34,10 +34,10 @@ type Datasize struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Datasize
-func LoadFromPath(ctx context.Context, path string) (ret *Datasize, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Datasize, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Datasize{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -50,10 +50,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Datasize, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Datasize
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Datasize, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Datasize, error) {
 	var ret Datasize
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Datasize{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/test_fixtures/gen/duration/Duration.pkl.go
+++ b/pkl/test_fixtures/gen/duration/Duration.pkl.go
@@ -26,10 +26,10 @@ type Duration struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Duration
-func LoadFromPath(ctx context.Context, path string) (ret *Duration, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Duration, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Duration{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -42,10 +42,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Duration, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Duration
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Duration, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Duration, error) {
 	var ret Duration
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Duration{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/test_fixtures/gen/dynamic/Dynamic.pkl.go
+++ b/pkl/test_fixtures/gen/dynamic/Dynamic.pkl.go
@@ -12,10 +12,10 @@ type Dynamic struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Dynamic
-func LoadFromPath(ctx context.Context, path string) (ret *Dynamic, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Dynamic, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Dynamic{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -28,10 +28,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Dynamic, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Dynamic
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Dynamic, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Dynamic, error) {
 	var ret Dynamic
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Dynamic{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/test_fixtures/gen/nullables/Nullables.pkl.go
+++ b/pkl/test_fixtures/gen/nullables/Nullables.pkl.go
@@ -70,10 +70,10 @@ type Nullables struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Nullables
-func LoadFromPath(ctx context.Context, path string) (ret *Nullables, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Nullables, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Nullables{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -86,10 +86,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Nullables, err error) 
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Nullables
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Nullables, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Nullables, error) {
 	var ret Nullables
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Nullables{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/test_fixtures/gen/primitives/Primitives.pkl.go
+++ b/pkl/test_fixtures/gen/primitives/Primitives.pkl.go
@@ -38,10 +38,10 @@ type Primitives struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Primitives
-func LoadFromPath(ctx context.Context, path string) (ret *Primitives, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Primitives, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Primitives{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -54,10 +54,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Primitives, err error)
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Primitives
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Primitives, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Primitives, error) {
 	var ret Primitives
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Primitives{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/test_fixtures/gen/unions/Unions.pkl.go
+++ b/pkl/test_fixtures/gen/unions/Unions.pkl.go
@@ -16,10 +16,10 @@ type Unions struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Unions
-func LoadFromPath(ctx context.Context, path string) (ret *Unions, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret Unions, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return Unions{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -32,10 +32,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *Unions, err error) {
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Unions
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*Unions, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Unions, error) {
 	var ret Unions
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return Unions{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/test_fixtures/gen/unknown_type/UnknownType.pkl.go
+++ b/pkl/test_fixtures/gen/unknown_type/UnknownType.pkl.go
@@ -12,10 +12,10 @@ type UnknownType struct {
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a UnknownType
-func LoadFromPath(ctx context.Context, path string) (ret *UnknownType, err error) {
+func LoadFromPath(ctx context.Context, path string) (ret UnknownType, err error) {
 	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
 	if err != nil {
-		return nil, err
+		return UnknownType{}, err
 	}
 	defer func() {
 		cerr := evaluator.Close()
@@ -28,10 +28,10 @@ func LoadFromPath(ctx context.Context, path string) (ret *UnknownType, err error
 }
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a UnknownType
-func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (*UnknownType, error) {
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (UnknownType, error) {
 	var ret UnknownType
 	if err := evaluator.EvaluateModule(ctx, source, &ret); err != nil {
-		return nil, err
+		return UnknownType{}, err
 	}
-	return &ret, nil
+	return ret, nil
 }

--- a/pkl/unmarshal_test.go
+++ b/pkl/unmarshal_test.go
@@ -310,29 +310,29 @@ func TestUnmarshal_Dynamic(t *testing.T) {
 
 func TestUnmarshal_Classes(t *testing.T) {
 	expected := classes.Classes{
-		Animals: []classes.Animal{
-			&classes.GreyhoundImpl{
-				DogImpl: &classes.DogImpl{
+		Animals: []classes.IAnimal{
+			&classes.Greyhound{
+				Dog: classes.Dog{
 					Name:  "Uni",
 					Barks: false,
 					Breed: "Greyhound",
 				},
 				CanRoach: true,
 			},
-			&classes.CatImpl{
+			&classes.Cat{
 				Name:  "Millie",
 				Meows: true,
 			},
 		},
-		MyAnimal: &classes.GreyhoundImpl{
-			DogImpl: &classes.DogImpl{
+		MyAnimal: &classes.Greyhound{
+			Dog: classes.Dog{
 				Name:  "Uni",
 				Barks: false,
 				Breed: "Greyhound",
 			},
 			CanRoach: true,
 		},
-		House: &classes.House{
+		House: classes.House{
 			Area:      2000,
 			Bedrooms:  3,
 			Bathrooms: 2,


### PR DESCRIPTION
This is half of the changes in #83 that only covers the changes to structs and pointer usages

> ### All fields with structs are always pointers to structs, rather than concrete structs
> 
> When providing a API interface to a dataset (such as a Restful API), it's normal for optional fields to be pointers, and non-optional fields to concrete types, including structs. This approach minimises the number of nil checks people have to do, and generally Go discourages the usage of pointers unless they're actually needed because you want to share a value.
> 
> Making every struct value in the generated code is very unergonomic, as it either requires nil checks littered at every level of your code that interacts with these structs, or (more likely) people don't bother with the nil checks, relying on Pkl to enforce the existence of values. However that approach means there's no indication as to what might break if a non-optional field is later make optional. By following go conventions, this change will result in build failures, rather the current runtime failures.