### PR TITLE
[Doc] Use fixed version instead of dynamic `latest` or placeholders

### DIFF
--- a/docs/modules/ROOT/pages/codegen.adoc
+++ b/docs/modules/ROOT/pages/codegen.adoc
@@ -8,7 +8,7 @@ Pkl code may turn into Go code by way of code generation.
 
 Code generation is done through the `pkl-gen-go` binary. To install:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 go install github.com/apple/pkl-go/cmd/pkl-gen-go@v{version}
 ----
@@ -27,7 +27,7 @@ Options may be provided to the code generator either using CLI flags, or using a
 [[settings-file]]
 === Settings file
 
-The settings file is a Pkl file that amends module https://pkl-lang.org/package-docs/pkg.pkl-lang.org/pkl-go/pkl.golang/current/GeneratorSettings/index.html[`package://pkg.pkl-lang.org/pkl-go/pkl.golang@{version}#/GeneratorSettings.pkl`].
+The settings file is a Pkl file that amends module https://pkl-lang.org/package-docs/pkg.pkl-lang.org/pkl-go/pkl.golang/{version}/GeneratorSettings/index.html[`package://pkg.pkl-lang.org/pkl-go/pkl.golang@{version}#/GeneratorSettings.pkl`].
 
 By default, the code generator will look for a `generator-settings.pkl` file residing in the current working directory.
 If found, it is used to configure the code generator.

--- a/docs/modules/ROOT/pages/codegen.adoc
+++ b/docs/modules/ROOT/pages/codegen.adoc
@@ -10,7 +10,7 @@ Code generation is done through the `pkl-gen-go` binary. To install:
 
 [source,bash]
 ----
-go install github.com/apple/pkl-go/cmd/pkl-gen-go@latest
+go install github.com/apple/pkl-go/cmd/pkl-gen-go@v{version}
 ----
 
 Once installed, Go may be generated from Pkl:
@@ -27,7 +27,7 @@ Options may be provided to the code generator either using CLI flags, or using a
 [[settings-file]]
 === Settings file
 
-The settings file is a Pkl file that amends module https://pkl-lang.org/package-docs/pkg.pkl-lang.org/pkl-go/pkl.golang/current/GeneratorSettings/index.html[`package://pkg.pkl-lang.org/pkl-go/pkl.golang@<VERSION>#/GeneratorSettings.pkl`].
+The settings file is a Pkl file that amends module https://pkl-lang.org/package-docs/pkg.pkl-lang.org/pkl-go/pkl.golang/current/GeneratorSettings/index.html[`package://pkg.pkl-lang.org/pkl-go/pkl.golang@{version}#/GeneratorSettings.pkl`].
 
 By default, the code generator will look for a `generator-settings.pkl` file residing in the current working directory.
 If found, it is used to configure the code generator.

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -21,7 +21,8 @@ The binaries are available as assets on our link:https://github.com/apple/pkl-go
 go install github.com/apple/pkl-go/cmd/pkl-gen-go@v{version}
 
 # via curl
-curl -L -o pkl-gen-go github.com/apple/pkl-go/releases/download/v{version}/pkl-gen-go-macos.bin
+# available platforms: macos, linux-amd64, and linux-aarch64
+curl -L -o pkl-gen-go github.com/apple/pkl-go/releases/download/v{version}/pkl-gen-go-<platform>.bin
 chmod +x pkl-gen-go
 ----
 
@@ -59,7 +60,7 @@ Code generation is done via the `pkl-gen-go` CLI. To install:
 
 [source,bash]
 ----
-go install github.com/apple/pkl-go/cmd/pkl-gen-go@latest
+go install github.com/apple/pkl-go/cmd/pkl-gen-go@v{version}
 ----
 
 In our example, Go sources can be generated using the following command:


### PR DESCRIPTION
Fixes some docs issues reported here #98 

I just assume that `{version}` can hold the latest version via doc generation.
Let me know if this is not the case 🙂 