### PR TITLE
Fix external reader test fibonacci implementation

### DIFF
--- a/cmd/internal/test-external-reader/test-external-reader.go
+++ b/cmd/internal/test-external-reader/test-external-reader.go
@@ -60,28 +60,21 @@ func (r fibReader) ListElements(baseURI url.URL) ([]pkl.PathElement, error) {
 }
 
 func (r fibReader) Read(uri url.URL) ([]byte, error) {
-	i, err := strconv.Atoi(uri.Opaque)
-	if i <= 0 {
+	n, err := strconv.Atoi(uri.Opaque)
+	if n <= 0 {
 		err = errors.New("non-positive value")
 	}
 	if err != nil {
 		return nil, fmt.Errorf("input uri must be in format fib:<positive integer>: %w", err)
 	}
 
-	fib := fibonacci()
-	result := 0
-	for range i {
-		result = fib()
-	}
-
-	return []byte(strconv.Itoa(result)), nil
+	return []byte(strconv.Itoa(fibonacci(n))), nil
 }
 
-func fibonacci() func() int {
+func fibonacci(n int) int {
 	f0, f1 := 0, 1
-	return func() int {
-		result := f0
+	for range n {
 		f0, f1 = f1, f0+f1
-		return result
 	}
+	return f0
 }

--- a/pkl/external_reader_test.go
+++ b/pkl/external_reader_test.go
@@ -71,9 +71,9 @@ func TestExternalReaderE2E(t *testing.T) {
 
 	output, err := evaluator.EvaluateOutputText(context.Background(), FileSource(tempDir+"/test.pkl"))
 	assert.NoError(t, err)
-	assert.Equal(t, output, `fib5 = 3
-fib10 = 34
-fib100 = 4181
+	assert.Equal(t, output, `fib5 = 5
+fib10 = 55
+fib100 = 6765
 fibErrA = "I/O error reading resource `+"`fib:%20`"+`. IOException: input uri must be in format fib:<positive integer>: non-positive value"
 fibErrB = "I/O error reading resource `+"`fib:abc`"+`. IOException: input uri must be in format fib:<positive integer>: non-positive value"
 fibErrC = "I/O error reading resource `+"`fib:-10`"+`. IOException: input uri must be in format fib:<positive integer>: non-positive value"


### PR DESCRIPTION
Realized this looked funny while working on https://github.com/apple/pkl-swift/pull/26. This fixes the off-by-one error.