### PR TITLE
Fix abstract class extending another abstract class.

### DIFF
--- a/codegen/snippet-tests/input/ExtendAbstractClass.pkl
+++ b/codegen/snippet-tests/input/ExtendAbstractClass.pkl
@@ -17,14 +17,22 @@
 module ExtendsAbstractClass
 
 import ".../src/go.pkl"
+import "support/lib3.pkl"
+import "support/lib2.pkl"
 
 abstract class A {
   b: String
+  c: lib3.GoGoGo
 }
 
-class B extends A {
+abstract class B extends A {
+  b = "hello"
+  e: lib2.Cities
+}
+
+class C extends B {
   b = "hi"
-  c: String
+  d: String
 }
 
 a: A

--- a/codegen/snippet-tests/output/IllegalOverride.err
+++ b/codegen/snippet-tests/output/IllegalOverride.err
@@ -31,8 +31,8 @@ xx | local fields: Map<String, GoStructField> = getFields(clazz, mappings)
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 at pkl.golang.internal.ClassGen#fields (file://<codegen_dir>/src/internal/ClassGen.pkl)
 
-xx | fields.values
-     ^^^^^^
+xx | (if (isAbstract) fields.values.filter((f) -> !f.isInherited) else fields.values)
+                                                                       ^^^^^^
 at pkl.golang.internal.ClassGen#imports (file://<codegen_dir>/src/internal/ClassGen.pkl)
 
 xx | when (!imports.isEmpty) {

--- a/codegen/snippet-tests/output/extendabstractclass/A.pkl.go
+++ b/codegen/snippet-tests/output/extendabstractclass/A.pkl.go
@@ -1,6 +1,10 @@
 // Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
 package extendabstractclass
 
+import "github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib3"
+
 type A interface {
 	GetB() string
+
+	GetC() lib3.GoGoGo
 }

--- a/codegen/snippet-tests/output/extendabstractclass/B.pkl.go
+++ b/codegen/snippet-tests/output/extendabstractclass/B.pkl.go
@@ -1,24 +1,10 @@
 // Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
 package extendabstractclass
 
+import "github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib2/cities"
+
 type B interface {
 	A
 
-	GetC() string
-}
-
-var _ B = (*BImpl)(nil)
-
-type BImpl struct {
-	B string `pkl:"b"`
-
-	C string `pkl:"c"`
-}
-
-func (rcv *BImpl) GetB() string {
-	return rcv.B
-}
-
-func (rcv *BImpl) GetC() string {
-	return rcv.C
+	GetE() cities.Cities
 }

--- a/codegen/snippet-tests/output/extendabstractclass/C.pkl.go
+++ b/codegen/snippet-tests/output/extendabstractclass/C.pkl.go
@@ -1,0 +1,41 @@
+// Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
+package extendabstractclass
+
+import (
+	"github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib2/cities"
+	"github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib3"
+)
+
+type C interface {
+	B
+
+	GetD() string
+}
+
+var _ C = (*CImpl)(nil)
+
+type CImpl struct {
+	B string `pkl:"b"`
+
+	D string `pkl:"d"`
+
+	E cities.Cities `pkl:"e"`
+
+	C lib3.GoGoGo `pkl:"c"`
+}
+
+func (rcv *CImpl) GetB() string {
+	return rcv.B
+}
+
+func (rcv *CImpl) GetD() string {
+	return rcv.D
+}
+
+func (rcv *CImpl) GetE() cities.Cities {
+	return rcv.E
+}
+
+func (rcv *CImpl) GetC() lib3.GoGoGo {
+	return rcv.C
+}

--- a/codegen/snippet-tests/output/extendabstractclass/init.pkl.go
+++ b/codegen/snippet-tests/output/extendabstractclass/init.pkl.go
@@ -5,5 +5,5 @@ import "github.com/apple/pkl-go/pkl"
 
 func init() {
 	pkl.RegisterMapping("ExtendsAbstractClass", ExtendsAbstractClass{})
-	pkl.RegisterMapping("ExtendsAbstractClass#B", BImpl{})
+	pkl.RegisterMapping("ExtendsAbstractClass#C", CImpl{})
 }

--- a/codegen/src/internal/ClassGen.pkl
+++ b/codegen/src/internal/ClassGen.pkl
@@ -93,7 +93,7 @@ local superClass: GoMapping.Class? = mappings.findOrNull((c) -> c is GoMapping.C
 local fields: Map<String, GoStructField> = getFields(clazz, mappings)
 
 local imports =
-  fields.values
+  (if (isAbstract) fields.values.filter((f) -> !f.isInherited) else fields.values)
     .flatMap((f) -> f.type.imports)
     .filter((i) -> i != classInfo.goPackage).distinct
   + (if (superClass != null && superClass.goPackage != classInfo.goPackage) List(superClass.goPackage) else List())


### PR DESCRIPTION
I've ran into a situation where I have:

```pkl
import "pkg.pkl"

abstract class A {
  field: pkg.Type
}

abstract class B extends A {
  secondField: String
}

class Concrete extends B {
  secondField = "defined"
  field { ... }
}
```

This would result in 3 class files being generated, with B.pkl.go:

```go
package mypackage

import "pkg"

type B interface {
	SomeField string
}
```

Since both A and B are abstract we generate interfaces. B should not have any imports as the `pkg.Type` is used in A.


## Before

- `A.pkl.go`
```go
// Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
package extendabstractclass

import "github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib3"

type A interface {
	GetB() string

	GetC() lib3.GoGoGo
}
```
- `B.pkl.go` (extra import, Go won't compile it)
```go
// Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
package extendabstractclass

import (
	"github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib2/cities"
	"github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib3"
)

type B interface {
	A

	GetE() cities.Cities
}
```
- `C.pkl.go`
```go
// Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
package extendabstractclass

import (
	"github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib2/cities"
	"github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib3"
)

type C interface {
	B

	GetD() string
}

var _ C = (*CImpl)(nil)

type CImpl struct {
	B string `pkl:"b"`

	D string `pkl:"d"`

	E cities.Cities `pkl:"e"`

	C lib3.GoGoGo `pkl:"c"`
}

func (rcv *CImpl) GetB() string {
	return rcv.B
}

func (rcv *CImpl) GetD() string {
	return rcv.D
}

func (rcv *CImpl) GetE() cities.Cities {
	return rcv.E
}

func (rcv *CImpl) GetC() lib3.GoGoGo {
	return rcv.C
}
```

## After

- `A.pkl.go`
```go
// Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
package extendabstractclass

import "github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib3"

type A interface {
	GetB() string

	GetC() lib3.GoGoGo
}
```
- `B.pkl.go`
```go
// Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
package extendabstractclass

import "github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib2/cities"

type B interface {
	A

	GetE() cities.Cities
}
```

- `C.pkl.go`
```go
// Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
package extendabstractclass

import (
	"github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib2/cities"
	"github.com/apple/pkl-go/codegen/snippet-tests/output/support/lib3"
)

type C interface {
	B

	GetD() string
}

var _ C = (*CImpl)(nil)

type CImpl struct {
	B string `pkl:"b"`

	D string `pkl:"d"`

	E cities.Cities `pkl:"e"`

	C lib3.GoGoGo `pkl:"c"`
}

func (rcv *CImpl) GetB() string {
	return rcv.B
}

func (rcv *CImpl) GetD() string {
	return rcv.D
}

func (rcv *CImpl) GetE() cities.Cities {
	return rcv.E
}

func (rcv *CImpl) GetC() lib3.GoGoGo {
	return rcv.C
}
```
