### PR TITLE
Fix DataSize.ToUnit conversion logic

### DIFF
--- a/pkl/values.go
+++ b/pkl/values.go
@@ -192,9 +192,11 @@ func (d *DataSize) String() string {
 
 // ToUnit converts this DataSize to the specified unit.
 func (d *DataSize) ToUnit(unit DataSizeUnit) DataSize {
+	valueBytes := d.Value * float64(d.Unit)
+	value := valueBytes / float64(unit)
 	return DataSize{
 		Unit:  unit,
-		Value: d.Value / float64(unit),
+		Value: value,
 	}
 }
 

--- a/pkl/values_test.go
+++ b/pkl/values_test.go
@@ -58,3 +58,40 @@ func TestDataSize_String(t *testing.T) {
 		})
 	}
 }
+
+func TestDataSize_ConvertToUnit(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    DataSize
+		expected DataSize
+	}{
+		{
+			name: "bytes_to_gigabytes",
+			input: DataSize{
+				Value: 1.0,
+				Unit:  Bytes,
+			},
+			expected: DataSize{
+				Value: 0.000_000_001,
+				Unit:  Gigabytes,
+			},
+		},
+		{
+			name: "megabytes_to_bytes",
+			input: DataSize{
+				Value: 1.0,
+				Unit:  Megabytes,
+			},
+			expected: DataSize{
+				Value: 1_000_000,
+				Unit:  Bytes,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.input.ToUnit(test.expected.Unit)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
- Fixes incorrect conversion from one unit to another by first converting to bytes, then dividing by target unit.
- Adds tests for conversion between bytes, megabytes, and gigabytes to ensure correctness.