### PR TITLE
Do not force `pkl.Pair` struct fields to be pointers

### DIFF
--- a/codegen/snippet-tests/input/Pairs.pkl
+++ b/codegen/snippet-tests/input/Pairs.pkl
@@ -1,0 +1,18 @@
+@go.Package { name = "github.com/apple/pkl-go/codegen/snippet-tests/output/pairs" }
+open module Pairs
+
+import ".../src/go.pkl"
+
+untyped: Pair
+
+optional: Pair?
+
+typed: Pair<String, Int>
+
+aliased: MyPair
+
+typeArgAliased: OurPair
+
+typealias MyPair = Pair<String, Any>
+typealias OurPair = Pair<String, Foo>
+typealias Foo = Int

--- a/codegen/snippet-tests/output/pairs/Pairs.pkl.go
+++ b/codegen/snippet-tests/output/pairs/Pairs.pkl.go
@@ -1,0 +1,77 @@
+// Code generated from Pkl module `Pairs`. DO NOT EDIT.
+package pairs
+
+import (
+	"context"
+
+	"github.com/apple/pkl-go/pkl"
+)
+
+type Pairs interface {
+	GetUntyped() pkl.Pair[any, any]
+
+	GetOptional() *pkl.Pair[any, any]
+
+	GetTyped() pkl.Pair[string, int]
+
+	GetAliased() pkl.Pair[string, any]
+
+	GetTypeArgAliased() pkl.Pair[string, int]
+}
+
+var _ Pairs = PairsImpl{}
+
+type PairsImpl struct {
+	Untyped pkl.Pair[any, any] `pkl:"untyped"`
+
+	Optional *pkl.Pair[any, any] `pkl:"optional"`
+
+	Typed pkl.Pair[string, int] `pkl:"typed"`
+
+	Aliased pkl.Pair[string, any] `pkl:"aliased"`
+
+	TypeArgAliased pkl.Pair[string, int] `pkl:"typeArgAliased"`
+}
+
+func (rcv PairsImpl) GetUntyped() pkl.Pair[any, any] {
+	return rcv.Untyped
+}
+
+func (rcv PairsImpl) GetOptional() *pkl.Pair[any, any] {
+	return rcv.Optional
+}
+
+func (rcv PairsImpl) GetTyped() pkl.Pair[string, int] {
+	return rcv.Typed
+}
+
+func (rcv PairsImpl) GetAliased() pkl.Pair[string, any] {
+	return rcv.Aliased
+}
+
+func (rcv PairsImpl) GetTypeArgAliased() pkl.Pair[string, int] {
+	return rcv.TypeArgAliased
+}
+
+// LoadFromPath loads the pkl module at the given path and evaluates it into a Pairs
+func LoadFromPath(ctx context.Context, path string) (ret Pairs, err error) {
+	evaluator, err := pkl.NewEvaluator(ctx, pkl.PreconfiguredOptions)
+	if err != nil {
+		return ret, err
+	}
+	defer func() {
+		cerr := evaluator.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	ret, err = Load(ctx, evaluator, pkl.FileSource(path))
+	return ret, err
+}
+
+// Load loads the pkl module at the given source and evaluates it with the given evaluator into a Pairs
+func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Pairs, error) {
+	var ret PairsImpl
+	err := evaluator.EvaluateModule(ctx, source, &ret)
+	return ret, err
+}

--- a/codegen/snippet-tests/output/pairs/init.pkl.go
+++ b/codegen/snippet-tests/output/pairs/init.pkl.go
@@ -1,0 +1,8 @@
+// Code generated from Pkl module `Pairs`. DO NOT EDIT.
+package pairs
+
+import "github.com/apple/pkl-go/pkl"
+
+func init() {
+	pkl.RegisterStrictMapping("Pairs", PairsImpl{})
+}

--- a/codegen/src/internal/typegen.pkl
+++ b/codegen/src/internal/typegen.pkl
@@ -124,13 +124,11 @@ function generatePair(
   enclosing: reflect.TypeDeclaration,
   seenMappings: List<GoMapping>
 ): Type =
-  new Type.Pointer {
-    elem = new Type.Declared {
-      typeName = "Pair"
-      package = "pkl"
-      importPath = "github.com/apple/pkl-go/pkl"
-      typeArguments = type.typeArguments.map((t) -> generateType(t, enclosing, seenMappings))
-    }
+  new Type.Declared {
+    typeName = "Pair"
+    package = "pkl"
+    importPath = "github.com/apple/pkl-go/pkl"
+    typeArguments = type.typeArguments.map((t) -> generateType(t, enclosing, seenMappings))
   }
 
 local function builtInType(typ: String): Type.Declared = new { typeName = typ }

--- a/codegen/src/tests/typegen.pkl
+++ b/codegen/src/tests/typegen.pkl
@@ -58,6 +58,8 @@ local reflectedNullables = reflect.Class(Nullables)
 local class Pairs {
   res1: Pair<String, String>
   res2: Pair<String, String?>
+  res3: Pair
+  res4: Pair<String, String>?
 }
 
 local reflectedPairs = reflect.Class(Pairs)
@@ -108,7 +110,9 @@ facts {
     generateType(reflectedNullables.properties["res8"].type) == "*map[*string]*string"
   }
   ["pairs"] {
-    generateType(reflectedPairs.properties["res1"].type) == "*pkl.Pair[string, string]"
-    generateType(reflectedPairs.properties["res2"].type) == "*pkl.Pair[string, *string]"
+    generateType(reflectedPairs.properties["res1"].type) == "pkl.Pair[string, string]"
+    generateType(reflectedPairs.properties["res2"].type) == "pkl.Pair[string, *string]"
+    generateType(reflectedPairs.properties["res3"].type) == "pkl.Pair[any, any]"
+    generateType(reflectedPairs.properties["res4"].type) == "*pkl.Pair[string, string]"
   }
 }

--- a/pkl/test_fixtures/gen/collections/Collections.pkl.go
+++ b/pkl/test_fixtures/gen/collections/Collections.pkl.go
@@ -28,11 +28,11 @@ type Collections struct {
 
 	Res10 map[int8]struct{} `pkl:"res10"`
 
-	Res11 *pkl.Pair[int, float64] `pkl:"res11"`
+	Res11 pkl.Pair[int, float64] `pkl:"res11"`
 
-	Res12 *pkl.Pair[any, any] `pkl:"res12"`
+	Res12 pkl.Pair[any, any] `pkl:"res12"`
 
-	Res13 *pkl.Pair[int, *int] `pkl:"res13"`
+	Res13 pkl.Pair[int, *int] `pkl:"res13"`
 
 	Res14 []byte `pkl:"res14"`
 }

--- a/pkl/unmarshal_test.go
+++ b/pkl/unmarshal_test.go
@@ -148,15 +148,15 @@ func TestUnmarshall_Collections(t *testing.T) {
 			2: {},
 			3: {},
 		},
-		Res11: &pkl.Pair[int, float64]{
+		Res11: pkl.Pair[int, float64]{
 			First:  1,
 			Second: 5.0,
 		},
-		Res12: &pkl.Pair[any, any]{
+		Res12: pkl.Pair[any, any]{
 			First:  "hello",
 			Second: "goodbye",
 		},
-		Res13: &pkl.Pair[int, *int]{
+		Res13: pkl.Pair[int, *int]{
 			First:  1,
 			Second: &[]int{2}[0],
 		},


### PR DESCRIPTION
This was missed as part of #136 and is similarly a breaking change, but only for generated code containing `pkl.Pair` struct fields.