### PR TITLE
Add `traceMode` support to `ProjectEvaluatorSettings`

### DIFF
--- a/pkl/decoder.go
+++ b/pkl/decoder.go
@@ -140,7 +140,13 @@ func (d *decoder) decodePointer(inType reflect.Type) (*reflect.Value, error) {
 		return val, nil
 	}
 	ret := reflect.New(inType.Elem())
-	ret.Elem().Set(*val)
+	if val.Type().AssignableTo(ret.Elem().Type()) {
+		ret.Elem().Set(*val)
+	} else if val.Type().ConvertibleTo(ret.Elem().Type()) {
+		ret.Elem().Set(val.Convert(ret.Elem().Type()))
+	} else {
+		return nil, fmt.Errorf("unable to assign or convert value of type `%s` to pointer of type `%s`", val.Type(), ret.Type())
+	}
 	return &ret, nil
 }
 

--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -486,6 +486,9 @@ var WithProjectEvaluatorSettings = func(project *Project) func(opts *EvaluatorOp
 				}
 			}
 		}
+		if evaluatorSettings.TraceMode != nil {
+			opts.TraceMode = *evaluatorSettings.TraceMode
+		}
 	}
 }
 

--- a/pkl/project.go
+++ b/pkl/project.go
@@ -78,6 +78,7 @@ type ProjectEvaluatorSettings struct {
 	Color                   string                                           `pkl:"color"`
 	ExternalModuleReaders   map[string]ProjectEvaluatorSettingExternalReader `pkl:"externalModuleReaders"`
 	ExternalResourceReaders map[string]ProjectEvaluatorSettingExternalReader `pkl:"externalResourceReaders"`
+	TraceMode               *TraceMode                                       `pkl:"traceMode"`
 }
 
 // ProjectEvaluatorSettingsHttp is the Go representation of pkl.EvaluatorSettings.Http

--- a/pkl/project_test.go
+++ b/pkl/project_test.go
@@ -174,6 +174,13 @@ evaluatorSettings {
   }
 }`
 
+const project6Contents = `
+amends "pkl:Project"
+
+evaluatorSettings {
+  traceMode = "pretty"
+}`
+
 func writeFile(t *testing.T, filename string, contents string) {
 	if err := os.WriteFile(filename, []byte(contents), 0o777); err != nil {
 		t.Logf("Failed to write file %s: %s", filename, err)
@@ -363,6 +370,32 @@ func TestLoadProjectWithRewrites(t *testing.T) {
 						"https://example.com/": "https://example.example/",
 					},
 				},
+			}
+			assert.Equal(t, expectedSettings, project.EvaluatorSettings)
+		})
+	}
+}
+
+func TestLoadProjectWithTraceMode(t *testing.T) {
+	manager := NewEvaluatorManager()
+	version, err := manager.(*evaluatorManager).getVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version.IsLessThan(internal.PklVersion0_30) {
+		t.SkipNow()
+	}
+
+	tempDir := t.TempDir()
+	_ = os.Mkdir(tempDir+"/pigeons", 0o777)
+	writeFile(t, tempDir+"/pigeons/PklProject", project6Contents)
+
+	project, err := LoadProject(context.Background(), tempDir+"/pigeons/PklProject")
+	if assert.NoError(t, err) {
+		t.Run("evaluatorSettings", func(t *testing.T) {
+			mode := TracePretty
+			expectedSettings := ProjectEvaluatorSettings{
+				TraceMode: &mode,
 			}
 			assert.Equal(t, expectedSettings, project.EvaluatorSettings)
 		})


### PR DESCRIPTION
This also adds support for decoding into struct fields and pointers with aliased field/referent types. In this case `string` value to field of type `pkl.TraceMode` or `*pkl.TraceMode`.