### PR TITLE
Properly report when no project file is found

### DIFF
--- a/cmd/pkl-gen-go/pkl-gen-go.go
+++ b/cmd/pkl-gen-go/pkl-gen-go.go
@@ -259,7 +259,11 @@ func findProjectDir(projectDirFlag string) *url.URL {
 	if err != nil {
 		return nil
 	}
-	return &url.URL{Scheme: "file", Path: doFindProjectDir(cwd)}
+	projectDir := doFindProjectDir(cwd)
+	if projectDir == "" {
+		return nil
+	}
+	return &url.URL{Scheme: "file", Path: projectDir}
 }
 
 // Loads the settings for controlling codegen.


### PR DESCRIPTION
Prevent crash when pkl-gen-go command cannot find a PklProject file.

Compare the execution of the attached test script with HEAD or release 0.12.0 and the proposed PR.

[test-no-pklproject.sh](https://github.com/user-attachments/files/23438956/test-no-pklproject.sh)
