### PR TITLE
Close channel in evaluatorManager's interrupted function to prevent r…

### DIFF
--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -262,6 +262,7 @@ func (m *evaluatorManager) interrupted(evaluatorId int64) (chan error, func()) {
 	m.interrupts.Store(ch, evaluatorId)
 	return ch, func() {
 		m.interrupts.Delete(ch)
+		close(ch)
 	}
 }
 


### PR DESCRIPTION
…esource leaks.