### PR TITLE
Allow custom/external resources to be "not found"

### DIFF
--- a/cmd/internal/test-external-reader/test-external-reader.go
+++ b/cmd/internal/test-external-reader/test-external-reader.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,9 +27,7 @@ import (
 )
 
 func main() {
-	client, err := pkl.NewExternalReaderClient(func(opts *pkl.ExternalReaderClientOptions) {
-		opts.ResourceReaders = append(opts.ResourceReaders, fibReader{})
-	})
+	client, err := pkl.NewExternalReaderClient(pkl.WithExternalClientResourceReader(fibReader{}))
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -61,8 +59,12 @@ func (r fibReader) ListElements(baseURI url.URL) ([]pkl.PathElement, error) {
 
 func (r fibReader) Read(uri url.URL) ([]byte, error) {
 	n, err := strconv.Atoi(uri.Opaque)
-	if n <= 0 {
-		err = errors.New("non-positive value")
+	if err == nil {
+		if n == 0 {
+			return nil, pkl.ResourceNotFound
+		} else if n < 0 {
+			err = errors.New("non-positive value")
+		}
 	}
 	if err != nil {
 		return nil, fmt.Errorf("input uri must be in format fib:<positive integer>: %w", err)

--- a/pkl/errors.go
+++ b/pkl/errors.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,9 +63,4 @@ func (r *InternalError) Is(err error) bool {
 	var internalError *InternalError
 	ok := errors.As(err, &internalError)
 	return ok
-}
-
-// Unwrap implements the interface expected by errors.Unwrap.
-func (r *InternalError) Unwrap() error {
-	return r.err
 }

--- a/pkl/evaluator.go
+++ b/pkl/evaluator.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -204,9 +204,13 @@ func (e *evaluator) handleReadResource(msg *msgapi.ReadResource) {
 		return
 	}
 	contents, err := reader.Read(*u)
-	response.Contents = contents
-	if err != nil {
+	switch {
+	case err == ResourceNotFound:
+		break
+	case err != nil:
 		response.Error = err.Error()
+	default:
+		response.Contents = &contents
 	}
 	e.manager.impl.outChan() <- response
 }

--- a/pkl/evaluator_test.go
+++ b/pkl/evaluator_test.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,6 +88,8 @@ func getOpenPort() int {
 
 func TestEvaluator(t *testing.T) {
 	manager := NewEvaluatorManager()
+	version, err := manager.(*evaluatorManager).getVersion()
+	assert.NoError(t, err)
 
 	projectDir := setupProject(t)
 
@@ -213,19 +215,42 @@ bar: Int = 5
 
 	t.Run("custom resource reader", func(t *testing.T) {
 		reader := &virtualResourceReader{
-			scheme: "flintstone",
+			scheme: "bird",
 			read: func(u url.URL) ([]byte, error) {
-				return []byte("Fred Flintstone"), nil
+				return []byte("caw"), nil
 			},
 		}
 		ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithResourceReader(reader))
 		if assert.NoError(t, err) {
-			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`foo = read("flintstone:fred").text`))
+			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`foo = read("bird:crow").text`))
 			assert.NoError(t, err)
-			assert.Equal(t, "foo = \"Fred Flintstone\"\n", out)
+			assert.Equal(t, "foo = \"caw\"\n", out)
 			assert.NoError(t, ev.Close())
 		}
 	})
+
+	// this test NPEs in pkl server before 0.27.0
+	if !version.IsLessThan(internal.PklVersion0_27) {
+		t.Run("custom resource not found", func(t *testing.T) {
+			reader := &virtualResourceReader{
+				scheme: "bird",
+				read: func(u url.URL) ([]byte, error) {
+					return nil, ResourceNotFound
+				},
+			}
+			ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithResourceReader(reader))
+			if assert.NoError(t, err) {
+				out, err := ev.EvaluateOutputText(context.Background(), TextSource(`foo = read?("bird:crow")?.text`))
+				assert.NoError(t, err)
+				if internal.PklVersion0_31_1.IsGreaterThan(version) {
+					assert.Equal(t, "foo = \"\"\n", out)
+				} else {
+					assert.Equal(t, "foo = null\n", out)
+				}
+				assert.NoError(t, ev.Close())
+			}
+		})
+	}
 
 	t.Run("custom resource reader with scheme containing regex control characters", func(t *testing.T) {
 		reader := &virtualResourceReader{
@@ -245,14 +270,14 @@ bar: Int = 5
 
 	t.Run("custom resource reader error", func(t *testing.T) {
 		reader := &virtualResourceReader{
-			scheme: "flintstone",
+			scheme: "bird",
 			read: func(url url.URL) ([]byte, error) {
 				return nil, fmt.Errorf("cannot find resource %s", &url)
 			},
 		}
 		ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithResourceReader(reader))
 		if assert.NoError(t, err) {
-			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`foo = read("flintstone:fred").text`))
+			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`foo = read("bird:crow").text`))
 			assert.Empty(t, out)
 			assert.Error(t, err)
 			assert.IsType(t, &EvalError{}, err)
@@ -262,45 +287,45 @@ bar: Int = 5
 
 	t.Run("custom resource reader: globbing", func(t *testing.T) {
 		reader := &virtualResourceReader{
-			scheme: "flintstone",
+			scheme: "bird",
 			read: func(u url.URL) ([]byte, error) {
 				switch u.Opaque {
-				case "barney":
-					return []byte("gumble"), nil
-				case "wilma":
-					return []byte("wilma"), nil
+				case "pigeon":
+					return []byte("coo"), nil
+				case "eagle":
+					return []byte("screech"), nil
 				default:
-					return []byte("something else"), nil
+					return []byte("caw"), nil
 				}
 			},
 			listElements: func(u url.URL) ([]PathElement, error) {
 				return []PathElement{
-					NewPathElement("barney", false),
-					NewPathElement("wilma", false),
-					NewPathElement("fred", false),
+					NewPathElement("pigeon", false),
+					NewPathElement("eagle", false),
+					NewPathElement("crow", false),
 				}, nil
 			},
 			isGlobbable: true,
 		}
 		ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithResourceReader(reader))
 		if assert.NoError(t, err) {
-			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`flintstones = read*("flintstone:*")`))
+			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`birds = read*("bird:*")`))
 			assert.Nil(t, err)
-			assert.Equal(t, `flintstones {
-  ["flintstone:barney"] {
-    uri = "flintstone:barney"
-    text = "gumble"
-    base64 = "Z3VtYmxl"
+			assert.Equal(t, `birds {
+  ["bird:crow"] {
+    uri = "bird:crow"
+    text = "caw"
+    base64 = "Y2F3"
   }
-  ["flintstone:fred"] {
-    uri = "flintstone:fred"
-    text = "something else"
-    base64 = "c29tZXRoaW5nIGVsc2U="
+  ["bird:eagle"] {
+    uri = "bird:eagle"
+    text = "screech"
+    base64 = "c2NyZWVjaA=="
   }
-  ["flintstone:wilma"] {
-    uri = "flintstone:wilma"
-    text = "wilma"
-    base64 = "d2lsbWE="
+  ["bird:pigeon"] {
+    uri = "bird:pigeon"
+    text = "coo"
+    base64 = "Y29v"
   }
 }
 `, out)
@@ -310,7 +335,7 @@ bar: Int = 5
 
 	t.Run("custom resource reader: glob error", func(t *testing.T) {
 		reader := &virtualResourceReader{
-			scheme: "flintstone",
+			scheme: "bird",
 			read: func(u url.URL) ([]byte, error) {
 				return nil, nil
 			},
@@ -321,7 +346,7 @@ bar: Int = 5
 		}
 		ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithResourceReader(reader))
 		if assert.NoError(t, err) {
-			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`flintstones = read*("flintstone:*")`))
+			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`birds = read*("bird:*")`))
 			assert.Empty(t, out)
 			assert.Error(t, err, "IOException: something went wrong")
 			assert.Zero(t, out)
@@ -331,14 +356,14 @@ bar: Int = 5
 
 	t.Run("custom module reader", func(t *testing.T) {
 		reader := &virtualModuleReader{
-			scheme: "flintstone",
+			scheme: "bird",
 			read: func(u url.URL) (string, error) {
 				return `foo = 1`, nil
 			},
 		}
 		ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithModuleReader(reader))
 		if assert.NoError(t, err) {
-			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`result = import("flintstone:fred").foo`))
+			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`result = import("bird:crow").foo`))
 			assert.NoError(t, err)
 			assert.Equal(t, "result = 1\n", out)
 			assert.NoError(t, ev.Close())
@@ -347,24 +372,24 @@ bar: Int = 5
 
 	t.Run("custom module reader error", func(t *testing.T) {
 		reader := &virtualModuleReader{
-			scheme: "flintstone",
+			scheme: "bird",
 			read: func(u url.URL) (string, error) {
 				return "", fmt.Errorf("no idea where %s is", &u)
 			},
 		}
 		ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithModuleReader(reader))
 		if assert.NoError(t, err) {
-			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`result = import("flintstone:fred").foo`))
+			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`result = import("bird:crow").foo`))
 			assert.Empty(t, out)
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "no idea where flintstone:fred is")
+			assert.Contains(t, err.Error(), "no idea where bird:crow is")
 			assert.NoError(t, ev.Close())
 		}
 	})
 
 	t.Run("custom module reader: triple-dot imports", func(t *testing.T) {
 		reader := &virtualModuleReader{
-			scheme:              "flintstone",
+			scheme:              "bird",
 			isGlobbable:         true,
 			hasHierarchicalUris: true,
 			isLocal:             true,
@@ -384,7 +409,7 @@ bar: Int = 5
 		}
 		ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithModuleReader(reader))
 		if assert.NoError(t, err) {
-			out, err := ev.EvaluateOutputText(context.Background(), UriSource("flintstone:/foo/bar/baz.pkl"))
+			out, err := ev.EvaluateOutputText(context.Background(), UriSource("bird:/foo/bar/baz.pkl"))
 			assert.NoError(t, err)
 			assert.Equal(t, `res {
   bar = 1
@@ -395,7 +420,7 @@ bar: Int = 5
 
 	t.Run("custom module reader: globbing", func(t *testing.T) {
 		reader := &virtualModuleReader{
-			scheme:              "flintstone",
+			scheme:              "bird",
 			isGlobbable:         true,
 			hasHierarchicalUris: true,
 			read: func(u url.URL) (string, error) {
@@ -419,13 +444,13 @@ bar: Int = 5
 		}
 		ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithModuleReader(reader))
 		if assert.NoError(t, err) {
-			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`res = import*("flintstone:/**.pkl")`))
+			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`res = import*("bird:/**.pkl")`))
 			assert.NoError(t, err)
 			assert.Equal(t, `res {
-  ["flintstone:/bar.pkl"] {
+  ["bird:/bar.pkl"] {
     res = 2
   }
-  ["flintstone:/foo.pkl"] {
+  ["bird:/foo.pkl"] {
     res = 1
   }
 }
@@ -435,7 +460,7 @@ bar: Int = 5
 
 	t.Run("custom module reader: glob error", func(t *testing.T) {
 		reader := &virtualModuleReader{
-			scheme:              "flintstone",
+			scheme:              "bird",
 			isGlobbable:         true,
 			hasHierarchicalUris: true,
 			read: func(u url.URL) (string, error) {
@@ -448,7 +473,7 @@ bar: Int = 5
 		}
 		ev, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithModuleReader(reader))
 		if assert.NoError(t, err) {
-			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`res = import*("flintstone:/**.pkl")`))
+			out, err := ev.EvaluateOutputText(context.Background(), TextSource(`res = import*("bird:/**.pkl")`))
 			assert.Error(t, err)
 			assert.Zero(t, out)
 		}
@@ -459,24 +484,24 @@ bar: Int = 5
 		if assert.NoError(t, err) {
 			out, err := ev.EvaluateOutputText(context.Background(), UriSource("testfs:/test_fixtures/testfs/person.pkl"))
 			assert.NoError(t, err)
-			assert.Equal(t, `name = "Barney"
-age = 43
+			assert.Equal(t, `name = "Pidgeon"
+age = 2
 `, out)
 			out, err = ev.EvaluateOutputText(context.Background(), UriSource("testfs:/test_fixtures/testfs/subdir/person.pkl"))
 			assert.NoError(t, err)
-			assert.Equal(t, `name = "Fred"
-age = 43
+			assert.Equal(t, `name = "Hawk"
+age = 2
 `, out)
 			out, err = ev.EvaluateOutputText(context.Background(), TextSource(`result = import*("testfs:/**.pkl")`))
 			assert.NoError(t, err)
 			assert.Equal(t, `result {
   ["testfs:/test_fixtures/testfs/person.pkl"] {
-    name = "Barney"
-    age = 43
+    name = "Pidgeon"
+    age = 2
   }
   ["testfs:/test_fixtures/testfs/subdir/person.pkl"] {
-    name = "Fred"
-    age = 43
+    name = "Hawk"
+    age = 2
   }
 }
 `, out)
@@ -526,7 +551,7 @@ someDuration = 5.min
 
 somePair = Pair("one", "two")
 
-bar = new Bar { name = "Barney" } 
+bar = new Bar { name = "Hawk" } 
 
 class Bar {
   name: String
@@ -537,7 +562,7 @@ class Bar {
 				SomeDuration: &Duration{5, Minute},
 				SomePair:     &Pair[string, string]{"one", "two"},
 				Bar: &TestLegacyBar{
-					Name: "Barney",
+					Name: "Hawk",
 				},
 			}, out)
 		}

--- a/pkl/external_reader.go
+++ b/pkl/external_reader.go
@@ -52,14 +52,14 @@ type ExternalReaderClientOptions struct {
 	ModuleReaders []ModuleReader
 }
 
-// WithExternalClientResourceReader adds an additional [ResourceReader] to the ExternalReaderClient.
+// WithExternalClientResourceReader adds a [ResourceReader] to the ExternalReaderClient.
 var WithExternalClientResourceReader = func(reader ResourceReader) func(*ExternalReaderClientOptions) {
 	return func(options *ExternalReaderClientOptions) {
 		options.ResourceReaders = append(options.ResourceReaders, reader)
 	}
 }
 
-// WithExternalClientModuleReader adds an additional [ModuleReader] to the ExternalReaderClient.
+// WithExternalClientModuleReader adds a [ModuleReader] to the ExternalReaderClient.
 var WithExternalClientModuleReader = func(reader ModuleReader) func(*ExternalReaderClientOptions) {
 	return func(options *ExternalReaderClientOptions) {
 		options.ModuleReaders = append(options.ModuleReaders, reader)
@@ -258,9 +258,13 @@ func (r *externalReaderClient) handleReadResource(msg *msgapi.ReadResource) {
 		return
 	}
 	contents, err := reader.Read(*u)
-	response.Contents = contents
-	if err != nil {
+	switch {
+	case err == ResourceNotFound:
+		break
+	case err != nil:
 		response.Error = err.Error()
+	default:
+		response.Contents = &contents
 	}
 	r.out <- response
 }

--- a/pkl/external_reader_test.go
+++ b/pkl/external_reader_test.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const externalReaderTest1 = `
+const (
+	externalReaderTest1 = `
 import "pkl:test"
 
 fib5 = read("fib:5").text.toInt()
@@ -37,6 +38,13 @@ fibErrA = test.catch(() -> read("fib:%20"))
 fibErrB = test.catch(() -> read("fib:abc"))
 fibErrC = test.catch(() -> read("fib:-10"))
 `
+	externalReaderTest2 = `
+import "pkl:test"
+
+fibNullable0 = read?("fib:0")?.text
+fibErrNotFound = test.catchOrNull(() -> read("fib:0").text)
+`
+)
 
 func TestExternalReaderE2E(t *testing.T) {
 	manager := NewEvaluatorManager()
@@ -75,8 +83,53 @@ func TestExternalReaderE2E(t *testing.T) {
 	assert.Equal(t, output, `fib5 = 5
 fib10 = 55
 fib100 = 6765
-fibErrA = "I/O error reading resource `+"`fib:%20`"+`. IOException: input uri must be in format fib:<positive integer>: non-positive value"
-fibErrB = "I/O error reading resource `+"`fib:abc`"+`. IOException: input uri must be in format fib:<positive integer>: non-positive value"
+fibErrA = "I/O error reading resource `+"`fib:%20`"+`. IOException: input uri must be in format fib:<positive integer>: strconv.Atoi: parsing \"%20\": invalid syntax"
+fibErrB = "I/O error reading resource `+"`fib:abc`"+`. IOException: input uri must be in format fib:<positive integer>: strconv.Atoi: parsing \"abc\": invalid syntax"
 fibErrC = "I/O error reading resource `+"`fib:-10`"+`. IOException: input uri must be in format fib:<positive integer>: non-positive value"
 `)
+}
+
+func TestExternalReaderNotFound(t *testing.T) {
+	manager := NewEvaluatorManager()
+	defer func() { _ = manager.Close() }()
+	version, err := manager.(*evaluatorManager).getVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if internal.PklVersion0_27.IsGreaterThan(version) {
+		t.SkipNow()
+	}
+
+	tempDir := t.TempDir()
+	writeFile(t, tempDir+"/test.pkl", externalReaderTest2)
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("can't find caller")
+	}
+	projectRoot := filepath.Join(filepath.Dir(filename), "../cmd/internal/test-external-reader/test-external-reader.go")
+
+	evaluator, err := manager.NewEvaluator(
+		context.Background(),
+		PreconfiguredOptions,
+		WithExternalResourceReader("fib", ExternalReader{
+			Executable: "go",
+			Arguments:  []string{"run", projectRoot},
+		}),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	output, err := evaluator.EvaluateOutputText(context.Background(), FileSource(tempDir+"/test.pkl"))
+	assert.NoError(t, err)
+	if internal.PklVersion0_31_1.IsGreaterThan(version) {
+		assert.Equal(t, output, `fibNullable0 = ""
+fibErrNotFound = null
+`)
+	} else {
+		assert.Equal(t, output, `fibNullable0 = null
+fibErrNotFound = "Cannot find resource `+"`fib:0`"+`."
+`)
+	}
 }

--- a/pkl/internal/msgapi/outgoing.go
+++ b/pkl/internal/msgapi/outgoing.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -140,10 +140,10 @@ func (msg *Evaluate) ToMsgPack() ([]byte, error) {
 }
 
 type ReadResourceResponse struct {
-	RequestId   int64  `msgpack:"requestId"`
-	EvaluatorId int64  `msgpack:"evaluatorId"`
-	Contents    []byte `msgpack:"contents,omitempty"`
-	Error       string `msgpack:"error,omitempty"`
+	RequestId   int64   `msgpack:"requestId"`
+	EvaluatorId int64   `msgpack:"evaluatorId"`
+	Contents    *[]byte `msgpack:"contents,omitempty"`
+	Error       string  `msgpack:"error,omitempty"`
 }
 
 func (msg *ReadResourceResponse) ToMsgPack() ([]byte, error) {

--- a/pkl/internal/version.go
+++ b/pkl/internal/version.go
@@ -48,6 +48,9 @@ var PklVersion0_30 = MustParseSemver("0.30.0")
 //goland:noinspection GoSnakeCaseUsage
 var PklVersion0_31 = MustParseSemver("0.31.0")
 
+//goland:noinspection GoSnakeCaseUsage
+var PklVersion0_31_1 = MustParseSemver("0.31.1")
+
 type Semver struct {
 	major                 int
 	minor                 int

--- a/pkl/reader.go
+++ b/pkl/reader.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package pkl
 
 import (
+	"errors"
 	"net/url"
 
 	"github.com/apple/pkl-go/pkl/internal/msgapi"
@@ -84,6 +85,12 @@ func NewPathElement(name string, isDirectory bool) PathElement {
 	return &pathElement{name: name, isDirectory: isDirectory}
 }
 
+// ResourceNotFound may be returned as an error by implementers of [ResourceReader.Read] to indicate
+// that no resource was found for the provided URI.
+//
+// This requires Pkl 0.31.1. Prior Pkl versions will interpret this as an empty resource.
+var ResourceNotFound = errors.New("resource not found")
+
 // ResourceReader is a custom resource reader for Pkl.
 //
 // A ResourceReader registers the scheme that it is responsible for reading via Reader.Scheme. For
@@ -105,6 +112,10 @@ type ResourceReader interface {
 	Reader
 
 	// Read reads the byte contents of this resource.
+	//
+	// Implementations may return [ResourceNotFound] as an error to indicate that no resource was
+	// found for the provided `url`.
+	// This requires Pkl 0.31.1. Prior Pkl versions will interpret this as an empty resource.
 	Read(url url.URL) ([]byte, error)
 }
 

--- a/pkl/test_fixtures/testfs/person.pkl
+++ b/pkl/test_fixtures/testfs/person.pkl
@@ -14,6 +14,6 @@
 // limitations under the License.
 // ===----------------------------------------------------------------------===//
 
-name: String = "Barney"
+name: String = "Pidgeon"
 
-age: Int = 43
+age: Int = 2

--- a/pkl/test_fixtures/testfs/subdir/person.pkl
+++ b/pkl/test_fixtures/testfs/subdir/person.pkl
@@ -16,4 +16,4 @@
 
 amends "..."
 
-name = "Fred"
+name = "Hawk"


### PR DESCRIPTION
This allows custom/external resources to produce `null` values for nullable reads (`read?`)

Resolves #157

Requires Pkl runtime with https://github.com/apple/pkl/pull/1471