### PR TITLE
fix: decode typed class instances into interface{} as Object

### DIFF
--- a/pkl/decode_struct.go
+++ b/pkl/decode_struct.go
@@ -55,6 +55,16 @@ func (d *decoder) decodeObject(typ reflect.Type) (*reflect.Value, error) {
 	if moduleUri == "pkl:base" && name == "Dynamic" || typ.AssignableTo(objectType) {
 		return d.decodeObjectGeneric(moduleUri, name)
 	}
+	// When the target type is an interface (e.g. interface{}) and there is no
+	// registered Go struct for this Pkl class, fall back to decoding as a
+	// generic Object. This allows typed class instances to be deserialized
+	// when they appear as values inside Dynamic objects or other containers
+	// that map to interface{}.
+	if typ.Kind() == reflect.Interface {
+		if _, hasSchema := d.schemas[name]; !hasSchema {
+			return d.decodeObjectGeneric(moduleUri, name)
+		}
+	}
 	return d.decodeTyped(name, typ)
 }
 

--- a/pkl/decoder_test.go
+++ b/pkl/decoder_test.go
@@ -487,6 +487,37 @@ func TestDecoder_Decode(t *testing.T) {
 				err: fmt.Errorf("encountered unknown object code: %#02x", 0x7F),
 			},
 		},
+		"should successfully decode typed class instance into interface{} as Object": {
+			typ: reflect.TypeOf((*interface{})(nil)).Elem(),
+			data: func(t *testing.T, enc *msgpack.Encoder) {
+				// Encode a typed class instance (e.g. authBasic.Config#AuthorizedUser)
+				// Same structure as Dynamic but with a custom class name and module URI
+				assert.NoError(t, enc.EncodeArrayLen(4))
+				assert.NoError(t, enc.EncodeInt(codeObject))
+				assert.NoError(t, enc.EncodeString("authBasic.Config#AuthorizedUser"))
+				assert.NoError(t, enc.EncodeString("projectpackage://pkg.pkl-lang.org/authBasic/config@1.0.0#/Config.pkl"))
+				// members array with 2 properties
+				assert.NoError(t, enc.EncodeArrayLen(2))
+				// property: username
+				assert.NoError(t, enc.EncodeArrayLen(3))
+				assert.NoError(t, enc.EncodeInt(codeObjectMemberProperty))
+				assert.NoError(t, enc.EncodeString("username"))
+				assert.NoError(t, enc.EncodeString("alice"))
+				// property: password
+				assert.NoError(t, enc.EncodeArrayLen(3))
+				assert.NoError(t, enc.EncodeInt(codeObjectMemberProperty))
+				assert.NoError(t, enc.EncodeString("password"))
+				assert.NoError(t, enc.EncodeString("$2a$10$hashedpassword"))
+			},
+			want: Object{
+				ModuleUri:  "projectpackage://pkg.pkl-lang.org/authBasic/config@1.0.0#/Config.pkl",
+				Name:       "authBasic.Config#AuthorizedUser",
+				Properties: map[string]any{"username": "alice", "password": "$2a$10$hashedpassword"},
+				Entries:    map[any]any{},
+				Elements:   []any{},
+			},
+			expectedErr: nil,
+		},
 		"should return error for struct with unknown code": {
 			typ: reflect.TypeOf(dummyStruct{}),
 			data: func(t *testing.T, enc *msgpack.Encoder) {

--- a/pkl/unmarshal_test.go
+++ b/pkl/unmarshal_test.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkl/unmarshal_test.go
+++ b/pkl/unmarshal_test.go
@@ -455,8 +455,13 @@ func TestUnmarshal_AnyType(t *testing.T) {
 func TestUnmarshal_UnknownType(t *testing.T) {
 	var res unknowntype.UnknownType
 	err := pkl.Unmarshal(unknownType, &res)
-	assert.Error(t, err)
-	assert.Equal(t, "cannot decode Pkl value of type `PcfRenderer` into Go type `interface {}`. Define a custom mapping for this using `pkl.RegisterMapping`", err.Error())
+	// When a typed class instance has no registered Go mapping and the target
+	// type is interface{}, it should be decoded as a pkl.Object (not error).
+	assert.NoError(t, err)
+	obj, ok := res.Res.(pkl.Object)
+	assert.True(t, ok, "expected pkl.Object, got %T", res.Res)
+	assert.Equal(t, "PcfRenderer", obj.Name)
+	assert.Equal(t, "pkl:base", obj.ModuleUri)
 }
 
 func TestUnmarshal_ArraysTooLong(t *testing.T) {


### PR DESCRIPTION
## Problem

When the decoder encounters a typed class instance (e.g., `MyModule#MyConfig`) and the Go target type is `interface{}`, it errors with:

```
cannot decode Pkl value of type 'MyModule#MyConfig' into Go type 'interface{}'.
Define a custom mapping for this using pkl.RegisterMapping
```

This happens because `decodeObject` only routes `Dynamic` objects and explicit `Object`-typed targets to `decodeObjectGeneric`. All other typed classes are routed to `decodeTyped`, which requires a registered Go struct mapping.

Dynamic objects and typed class instances have the same wire format - properties, entries, and elements. The only difference is the class name. There's no structural reason to reject typed classes when the Go target is `interface{}`.

## Use case

We maintain a plugin architecture where plugin authors define typed PKL configuration classes that extend a base class:

```pkl
// Defined by plugin author
class AgentConfig extends BaseAgentAuthConfig {
    type = "auth-basic"
    authorizedUsers: Listing<AuthorizedUser>
}
```

The host application deserializes plugin config as `pkl.Object` (via a `pkl.Object`-tagged struct field) because it cannot (or shouldn't) know all plugin types at compile time. The config is passed through as `json.RawMessage` to the plugin process, which handles its own deserialization.

This breaks when the config contains typed class instances (like `AuthorizedUser`) nested inside the `pkl.Object.Properties` map - each property value targets `interface{}`, and typed classes are rejected.

Registering mappings via `pkl.RegisterMapping` is not viable here because plugin types are defined externally and are not known to the host at compile time.

## Fix

When the target type is `interface{}` and no Go struct mapping is registered for the Pkl class, fall back to `decodeObjectGeneric` (producing a `*pkl.Object`). If a mapping IS registered, the existing typed decoding path is used.

This is consistent with how `Dynamic` objects are already handled - typed classes are structurally identical on the wire.