### PR TITLE
Fix codegen of extending modules

### DIFF
--- a/codegen/snippet-tests/input/Unions.pkl
+++ b/codegen/snippet-tests/input/Unions.pkl
@@ -16,6 +16,8 @@
 @go.Package { name = "github.com/apple/pkl-go/codegen/snippet-tests/output/union" }
 module union
 
+extends "support/OpenModule.pkl"
+
 import ".../src/go.pkl"
 
 /// A city
@@ -30,6 +32,8 @@ noodle: Noodles
 /// Account disposition
 disposition: AccountDisposition
 
+directory: Listing<DirectoryEntry>?
+
 /// City; e.g. where people live
 typealias City = "San Francisco" | "London" | "上海"
 
@@ -40,3 +44,13 @@ typealias County = "San Francisco" | "San Mateo" | "Yolo"
 typealias Noodles = "拉面" | "刀切面" | "面线" | "意大利面"
 
 typealias AccountDisposition = "" | "icloud3" | "prod" | "shared"
+
+typealias DirectoryEntry = *File | Directory
+
+class File {
+  name: String
+}
+
+class Directory {
+  name: String
+}

--- a/codegen/snippet-tests/input/support/OpenModule.pkl
+++ b/codegen/snippet-tests/input/support/OpenModule.pkl
@@ -19,3 +19,7 @@ open module MyModule
 import ".../src/go.pkl"
 
 foo: String
+
+output {
+  text = foo
+}

--- a/codegen/snippet-tests/output/union/Directory.pkl.go
+++ b/codegen/snippet-tests/output/union/Directory.pkl.go
@@ -1,0 +1,6 @@
+// Code generated from Pkl module `union`. DO NOT EDIT.
+package union
+
+type Directory struct {
+	Name string `pkl:"name"`
+}

--- a/codegen/snippet-tests/output/union/File.pkl.go
+++ b/codegen/snippet-tests/output/union/File.pkl.go
@@ -1,0 +1,6 @@
+// Code generated from Pkl module `union`. DO NOT EDIT.
+package union
+
+type File struct {
+	Name string `pkl:"name"`
+}

--- a/codegen/snippet-tests/output/union/Union.pkl.go
+++ b/codegen/snippet-tests/output/union/Union.pkl.go
@@ -4,6 +4,7 @@ package union
 import (
 	"context"
 
+	"github.com/apple/pkl-go/codegen/snippet-tests/output/support/openmodule"
 	"github.com/apple/pkl-go/codegen/snippet-tests/output/union/accountdisposition"
 	"github.com/apple/pkl-go/codegen/snippet-tests/output/union/city"
 	"github.com/apple/pkl-go/codegen/snippet-tests/output/union/county"
@@ -11,7 +12,25 @@ import (
 	"github.com/apple/pkl-go/pkl"
 )
 
-type Union struct {
+type Union interface {
+	openmodule.MyModule
+
+	GetCity() city.City
+
+	GetCounty() county.County
+
+	GetNoodle() noodles.Noodles
+
+	GetDisposition() accountdisposition.AccountDisposition
+
+	GetDirectory() *[]any
+}
+
+var _ Union = UnionImpl{}
+
+type UnionImpl struct {
+	openmodule.MyModuleImpl
+
 	// A city
 	City city.City `pkl:"city"`
 
@@ -23,6 +42,32 @@ type Union struct {
 
 	// Account disposition
 	Disposition accountdisposition.AccountDisposition `pkl:"disposition"`
+
+	Directory *[]any `pkl:"directory"`
+}
+
+// A city
+func (rcv UnionImpl) GetCity() city.City {
+	return rcv.City
+}
+
+// County
+func (rcv UnionImpl) GetCounty() county.County {
+	return rcv.County
+}
+
+// Noodles
+func (rcv UnionImpl) GetNoodle() noodles.Noodles {
+	return rcv.Noodle
+}
+
+// Account disposition
+func (rcv UnionImpl) GetDisposition() accountdisposition.AccountDisposition {
+	return rcv.Disposition
+}
+
+func (rcv UnionImpl) GetDirectory() *[]any {
+	return rcv.Directory
 }
 
 // LoadFromPath loads the pkl module at the given path and evaluates it into a Union
@@ -43,7 +88,7 @@ func LoadFromPath(ctx context.Context, path string) (ret Union, err error) {
 
 // Load loads the pkl module at the given source and evaluates it with the given evaluator into a Union
 func Load(ctx context.Context, evaluator pkl.Evaluator, source *pkl.ModuleSource) (Union, error) {
-	var ret Union
+	var ret UnionImpl
 	err := evaluator.EvaluateModule(ctx, source, &ret)
 	return ret, err
 }

--- a/codegen/snippet-tests/output/union/init.pkl.go
+++ b/codegen/snippet-tests/output/union/init.pkl.go
@@ -4,5 +4,7 @@ package union
 import "github.com/apple/pkl-go/pkl"
 
 func init() {
-	pkl.RegisterStrictMapping("union", Union{})
+	pkl.RegisterStrictMapping("union", UnionImpl{})
+	pkl.RegisterStrictMapping("union#Directory", Directory{})
+	pkl.RegisterStrictMapping("union#File", File{})
 }

--- a/codegen/src/Generator.pkl
+++ b/codegen/src/Generator.pkl
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Generates Go sources from Pkl
-@ModuleInfo { minPklVersion = "0.29.0" }
+@ModuleInfo { minPklVersion = "0.30.0" }
 module pkl.golang.Generator
 
 import "pkl:reflect"

--- a/codegen/src/internal/ClassGen.pkl
+++ b/codegen/src/internal/ClassGen.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -154,7 +154,7 @@ function getFields(clazz: reflect.Class, mappings: List<GoMapping>): Map<String,
       .filter((propName, prop: reflect.Property) ->
         let (superProp = superProperties.findOrNull((it) -> it.name == prop.name))
           // don't render hidden members
-          if (prop.modifiers.contains("hidden"))
+          if (prop.allModifiers.contains("hidden"))
             false
             // Okay if there is no property override, or if the super property has the same type.
           else if (superProp == null || isSameType(superProp.type, prop.type))

--- a/codegen/src/internal/gatherer.pkl
+++ b/codegen/src/internal/gatherer.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,7 +46,9 @@ function gatherTypeDeclarations(
         |> gatherModuleTypeAliases(decl)
         |> gatherModule(decl)
   else if (decl is reflect.TypeAlias)
-    seen.add(decl) |> gatherTypeArguments(decl)
+    seen.add(decl)
+      |> gatherTypeArguments(decl)
+      |> (_seen) -> gatherTypeDeclarationsFromType(decl.referent, decl, _seen)
   else
     seen
 
@@ -78,7 +80,7 @@ function gatherTypeDeclarationsFromType(
 
 function gatherPropertiesDeclarations(clazz: reflect.Class) = (seen: List<reflect.TypeDeclaration>) ->
   clazz.properties.values
-    .filter((p) -> !p.modifiers.contains("hidden"))
+    .filter((p) -> !p.allModifiers.contains("hidden"))
     .fold(seen, (acc, p) -> gatherTypeDeclarationsFromType(p.type, clazz, acc))
 
 function gatherSuperDeclarations(clazz: reflect.Class) = (seen: List<reflect.TypeDeclaration>) ->


### PR DESCRIPTION
* Fix generation of properties that are hidden by a parent module but amended without modifier in a sub-module.
* Fix generation of types defined in extending modules only reachable via a typealias.

Resolves #233
Resolves #234