### PR TITLE
Refactor random number generation in evaluator to use math/rand/v2 pa…

### DIFF
--- a/pkl/atomic.go
+++ b/pkl/atomic.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkl/atomic.go
+++ b/pkl/atomic.go
@@ -17,10 +17,7 @@
 package pkl
 
 import (
-	"math/rand"
-	"sync"
 	"sync/atomic"
-	"time"
 )
 
 type atomicBool struct {
@@ -34,19 +31,3 @@ func (a *atomicBool) get() bool {
 func (a *atomicBool) set(value bool) {
 	a.Store(value)
 }
-
-var randPool = &sync.Pool{
-	New: func() interface{} {
-		return rand.New(rand.NewSource(time.Now().UnixNano()))
-	},
-}
-
-type atomicRandom struct{}
-
-func (a *atomicRandom) Int63() int64 {
-	r := randPool.Get().(*rand.Rand)
-	defer randPool.Put(r)
-	return r.Int63()
-}
-
-var random = &atomicRandom{}

--- a/pkl/evaluator.go
+++ b/pkl/evaluator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand/v2"
 	"net/url"
 	"sync"
 
@@ -128,7 +129,7 @@ func (e *evaluator) EvaluateExpressionRaw(ctx context.Context, source *ModuleSou
 	if e.Closed() {
 		return nil, fmt.Errorf("evaluator is closed")
 	}
-	requestId := random.Int63()
+	requestId := rand.Int64()
 	ch := make(chan *msgapi.EvaluateResponse)
 	e.pendingRequests.Store(requestId, ch)
 	interrupted, nevermind := e.manager.interrupted(e.evaluatorId)

--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"math/rand/v2"
 	"net/url"
 	"sync"
 
@@ -106,7 +107,7 @@ func (m *evaluatorManager) NewEvaluator(ctx context.Context, opts ...func(option
 		return nil, err
 	}
 	var newEvaluatorRequest msgapi.OutgoingMessage
-	requestId := random.Int63()
+	requestId := rand.Int64()
 	msg := o.toMessage()
 	msg.RequestId = requestId
 	newEvaluatorRequest = msg


### PR DESCRIPTION
…ckage

- Removed custom atomic random implementation from atomic.go.
- Updated evaluator_manager.go and evaluator.go to utilize rand.Int64() for generating request IDs instead of the removed atomic random method.