### PR TITLE
Add support for resolved evaluator settings

### DIFF
--- a/pkl/evaluator_exec.go
+++ b/pkl/evaluator_exec.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkl/evaluator_exec.go
+++ b/pkl/evaluator_exec.go
@@ -18,6 +18,7 @@ package pkl
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	"github.com/apple/pkl-go/pkl/internal"
@@ -72,8 +73,19 @@ func NewProjectEvaluatorWithCommand(ctx context.Context, projectBaseUrl *url.URL
 	if err != nil {
 		return nil, err
 	}
-	newOpts := []func(options *EvaluatorOptions){
-		WithProject(project),
+	version, err := manager.GetVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get version from manager: %w", err)
+	}
+	semver, err := internal.ParseSemver(version)
+	if err != nil {
+		return nil, fmt.Errorf("manager returned an invalid semver string: %s. Parsing error: %w", version, err)
+	}
+	var newOpts []func(options *EvaluatorOptions)
+	if semver.IsLessThan(internal.PklVersion0_32) {
+		newOpts = append(newOpts, WithProjectLegacy(project))
+	} else {
+		newOpts = append(newOpts, WithProject(project))
 	}
 	newOpts = append(newOpts, opts...)
 	ev, err := manager.NewEvaluator(ctx, newOpts...)

--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -145,6 +145,12 @@ func (m *evaluatorManager) NewEvaluator(ctx context.Context, opts ...func(option
 
 func (m *evaluatorManager) NewProjectEvaluator(ctx context.Context, projectBaseUrl *url.URL, opts ...func(options *EvaluatorOptions)) (Evaluator, error) {
 	projectEvaluator, err := NewEvaluator(ctx, opts...)
+	defer func() {
+		cerr := projectEvaluator.Close()
+		if err != nil {
+			err = cerr
+		}
+	}()
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +159,15 @@ func (m *evaluatorManager) NewProjectEvaluator(ctx context.Context, projectBaseU
 	if err != nil {
 		return nil, err
 	}
-	newOpts := []func(options *EvaluatorOptions){
-		WithProject(project),
+	version, err := m.getVersion()
+	if err != nil {
+		return nil, err
+	}
+	var newOpts []func(options *EvaluatorOptions)
+	if version.IsLessThan(internal.PklVersion0_32) {
+		newOpts = append(newOpts, WithProjectLegacy(project))
+	} else {
+		newOpts = append(newOpts, WithProject(project))
 	}
 	newOpts = append(newOpts, opts...)
 	return NewEvaluator(ctx, newOpts...)

--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -451,36 +451,48 @@ var WithFs = func(fs fs.FS, scheme string) func(opts *EvaluatorOptions) {
 
 // WithProjectEvaluatorSettings configures the evaluator with settings from the given
 // ProjectEvaluatorSettings.
+//
+//goland:noinspection DuplicatedCode
 var WithProjectEvaluatorSettings = func(project *Project) func(opts *EvaluatorOptions) {
 	return func(opts *EvaluatorOptions) {
-		evaluatorSettings := project.EvaluatorSettings
-		opts.Properties = evaluatorSettings.ExternalProperties
-		opts.Env = evaluatorSettings.Env
-		if evaluatorSettings.AllowedModules != nil {
-			opts.AllowedModules = *evaluatorSettings.AllowedModules
-		}
-		if evaluatorSettings.AllowedResources != nil {
-			opts.AllowedResources = *evaluatorSettings.AllowedResources
-		}
-		if evaluatorSettings.NoCache != nil && *evaluatorSettings.NoCache {
-			opts.CacheDir = ""
-		} else {
-			opts.CacheDir = evaluatorSettings.ModuleCacheDir
-		}
-		opts.RootDir = evaluatorSettings.RootDir
-		if evaluatorSettings.Http != nil {
-			opts.Http = &Http{}
-			if evaluatorSettings.Http.Proxy != nil {
-				opts.Http.Proxy = &Proxy{}
-				if evaluatorSettings.Http.Proxy.NoProxy != nil {
-					opts.Http.Proxy.NoProxy = *evaluatorSettings.Http.Proxy.NoProxy
-				}
-				if evaluatorSettings.Http.Proxy.Address != nil {
-					opts.Http.Proxy.Address = *evaluatorSettings.Http.Proxy.Address
-				}
+		applyFromProjectEvaluatorSettings(project.ResolvedEvaluatorSettings, opts)
+	}
+}
+
+// WithProjectEvaluatorSettingsLegacy is like WithProjectEvaluatorSettings, but uses the _unresolved_ evaluator
+// settings.
+//
+// This should be avoided when using Pkl 0.32 or newer.
+var WithProjectEvaluatorSettingsLegacy = func(project *Project) func(opts *EvaluatorOptions) {
+	return func(opts *EvaluatorOptions) {
+		applyFromProjectEvaluatorSettings(project.EvaluatorSettings, opts)
+	}
+}
+
+var applyFromProjectEvaluatorSettings = func(evaluatorSettings ProjectEvaluatorSettings, opts *EvaluatorOptions) {
+	opts.Properties = evaluatorSettings.ExternalProperties
+	opts.Env = evaluatorSettings.Env
+	if evaluatorSettings.AllowedModules != nil {
+		opts.AllowedModules = *evaluatorSettings.AllowedModules
+	}
+	if evaluatorSettings.AllowedResources != nil {
+		opts.AllowedResources = *evaluatorSettings.AllowedResources
+	}
+	if evaluatorSettings.NoCache != nil && *evaluatorSettings.NoCache {
+		opts.CacheDir = ""
+	} else {
+		opts.CacheDir = evaluatorSettings.ModuleCacheDir
+	}
+	opts.RootDir = evaluatorSettings.RootDir
+	if evaluatorSettings.Http != nil {
+		opts.Http = &Http{}
+		if evaluatorSettings.Http.Proxy != nil {
+			opts.Http.Proxy = &Proxy{}
+			if evaluatorSettings.Http.Proxy.NoProxy != nil {
+				opts.Http.Proxy.NoProxy = *evaluatorSettings.Http.Proxy.NoProxy
 			}
-			if evaluatorSettings.Http.Rewrites != nil {
-				opts.Http.Rewrites = *evaluatorSettings.Http.Rewrites
+			if evaluatorSettings.Http.Proxy.Address != nil {
+				opts.Http.Proxy.Address = *evaluatorSettings.Http.Proxy.Address
 			}
 			if evaluatorSettings.Http.Headers != nil {
 				opts.Http.Headers = make(map[string]http.Header, len(*evaluatorSettings.Http.Headers))
@@ -506,29 +518,32 @@ var WithProjectEvaluatorSettings = func(project *Project) func(opts *EvaluatorOp
 				}
 			}
 		}
-		if evaluatorSettings.ExternalModuleReaders != nil {
-			opts.ExternalModuleReaders = make(map[string]ExternalReader, len(evaluatorSettings.ExternalModuleReaders))
-			for scheme, reader := range evaluatorSettings.ExternalModuleReaders {
-				opts.ExternalModuleReaders[scheme] = ExternalReader(reader)
-				if evaluatorSettings.AllowedModules == nil { // if no explicit allowed modules are set in the project, allow declared external module readers
-					WithDefaultAllowedModules(opts)
-					opts.AllowedModules = append(opts.AllowedModules, regexp.QuoteMeta(scheme+":"))
-				}
+		if evaluatorSettings.Http.Rewrites != nil {
+			opts.Http.Rewrites = *evaluatorSettings.Http.Rewrites
+		}
+	}
+	if evaluatorSettings.ExternalModuleReaders != nil {
+		opts.ExternalModuleReaders = make(map[string]ExternalReader, len(evaluatorSettings.ExternalModuleReaders))
+		for scheme, reader := range evaluatorSettings.ExternalModuleReaders {
+			opts.ExternalModuleReaders[scheme] = ExternalReader(reader)
+			if evaluatorSettings.AllowedModules == nil { // if no explicit allowed modules are set in the project, allow declared external module readers
+				WithDefaultAllowedModules(opts)
+				opts.AllowedModules = append(opts.AllowedModules, regexp.QuoteMeta(scheme+":"))
 			}
 		}
-		if evaluatorSettings.ExternalResourceReaders != nil {
-			opts.ExternalResourceReaders = make(map[string]ExternalReader, len(evaluatorSettings.ExternalResourceReaders))
-			for scheme, reader := range evaluatorSettings.ExternalResourceReaders {
-				opts.ExternalResourceReaders[scheme] = ExternalReader(reader)
-				if evaluatorSettings.AllowedResources == nil { // if no explicit allowed resources are set in the project, allow declared external resource readers
-					WithDefaultAllowedResources(opts)
-					opts.AllowedResources = append(opts.AllowedResources, regexp.QuoteMeta(scheme+":"))
-				}
+	}
+	if evaluatorSettings.ExternalResourceReaders != nil {
+		opts.ExternalResourceReaders = make(map[string]ExternalReader, len(evaluatorSettings.ExternalResourceReaders))
+		for scheme, reader := range evaluatorSettings.ExternalResourceReaders {
+			opts.ExternalResourceReaders[scheme] = ExternalReader(reader)
+			if evaluatorSettings.AllowedResources == nil { // if no explicit allowed resources are set in the project, allow declared external resource readers
+				WithDefaultAllowedResources(opts)
+				opts.AllowedResources = append(opts.AllowedResources, regexp.QuoteMeta(scheme+":"))
 			}
 		}
-		if evaluatorSettings.TraceMode != nil {
-			opts.TraceMode = *evaluatorSettings.TraceMode
-		}
+	}
+	if evaluatorSettings.TraceMode != nil {
+		opts.TraceMode = *evaluatorSettings.TraceMode
 	}
 }
 
@@ -540,9 +555,20 @@ var WithProjectDependencies = func(project *Project) func(opts *EvaluatorOptions
 	}
 }
 
+// WithProject configures the options with the dependencies and resolved evaluator settings defined in Project.
 var WithProject = func(project *Project) func(opts *EvaluatorOptions) {
 	return func(opts *EvaluatorOptions) {
 		WithProjectEvaluatorSettings(project)(opts)
+		WithProjectDependencies(project)(opts)
+	}
+}
+
+// WithProjectLegacy configures the options with the dependencies and unresolved evaluator settings defined in Project.
+//
+// If using Pkl 0.32 or newer, prefer WithProject over this method.
+var WithProjectLegacy = func(project *Project) func(opts *EvaluatorOptions) {
+	return func(opts *EvaluatorOptions) {
+		WithProjectEvaluatorSettingsLegacy(project)(opts)
 		WithProjectDependencies(project)(opts)
 	}
 }

--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -494,32 +494,32 @@ var applyFromProjectEvaluatorSettings = func(evaluatorSettings ProjectEvaluatorS
 			if evaluatorSettings.Http.Proxy.Address != nil {
 				opts.Http.Proxy.Address = *evaluatorSettings.Http.Proxy.Address
 			}
-			if evaluatorSettings.Http.Headers != nil {
-				opts.Http.Headers = make(map[string]http.Header, len(*evaluatorSettings.Http.Headers))
-				for pattern, headers := range *evaluatorSettings.Http.Headers {
-					h := make(http.Header, len(headers))
-					opts.Http.Headers[pattern] = h
-					for header, value := range headers {
-						switch val := value.(type) {
-						case string:
-							h.Add(header, val)
-						case []any:
-							for idx, v := range val {
-								if vv, ok := v.(string); ok {
-									h.Add(header, vv)
-								} else {
-									panic(fmt.Sprintf("unexpected value of type %T in project at evaluatorSettings.http.headers[%q][%q][%d]", value, pattern, header, idx))
-								}
-							}
-						default:
-							panic(fmt.Sprintf("unexpected value of type %T in project at evaluatorSettings.http.headers[%q][%q]", value, pattern, header))
-						}
-					}
-				}
-			}
 		}
 		if evaluatorSettings.Http.Rewrites != nil {
 			opts.Http.Rewrites = *evaluatorSettings.Http.Rewrites
+		}
+		if evaluatorSettings.Http.Headers != nil {
+			opts.Http.Headers = make(map[string]http.Header, len(*evaluatorSettings.Http.Headers))
+			for pattern, headers := range *evaluatorSettings.Http.Headers {
+				h := make(http.Header, len(headers))
+				opts.Http.Headers[pattern] = h
+				for header, value := range headers {
+					switch val := value.(type) {
+					case string:
+						h.Add(header, val)
+					case []any:
+						for idx, v := range val {
+							if vv, ok := v.(string); ok {
+								h.Add(header, vv)
+							} else {
+								panic(fmt.Sprintf("unexpected value of type %T in project at evaluatorSettings.http.headers[%q][%q][%d]", value, pattern, header, idx))
+							}
+						}
+					default:
+						panic(fmt.Sprintf("unexpected value of type %T in project at evaluatorSettings.http.headers[%q][%q]", value, pattern, header))
+					}
+				}
+			}
 		}
 	}
 	if evaluatorSettings.ExternalModuleReaders != nil {

--- a/pkl/evaluator_test.go
+++ b/pkl/evaluator_test.go
@@ -88,8 +88,11 @@ func getOpenPort() int {
 
 func TestEvaluator(t *testing.T) {
 	manager := NewEvaluatorManager()
+
 	version, err := manager.(*evaluatorManager).getVersion()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	projectDir := setupProject(t)
 
@@ -118,10 +121,6 @@ func TestEvaluator(t *testing.T) {
 	})
 
 	t.Run("EvaluateOutputBytes", func(t *testing.T) {
-		version, err := manager.(*evaluatorManager).getVersion()
-		if err != nil {
-			t.Fatal(err)
-		}
 		if version.IsLessThan(internal.PklVersion0_29) {
 			t.SkipNow()
 		}
@@ -153,10 +152,6 @@ func TestEvaluator(t *testing.T) {
 	})
 
 	t.Run("EvaluateOutputFilesBytes", func(t *testing.T) {
-		version, err := manager.(*evaluatorManager).getVersion()
-		if err != nil {
-			t.Fatal(err)
-		}
 		if version.IsLessThan(internal.PklVersion0_29) {
 			t.SkipNow()
 		}
@@ -644,10 +639,6 @@ class Bar {
 	})
 
 	t.Run("custom proxy options errors on Pkl 0.25", func(t *testing.T) {
-		version, err := manager.(*evaluatorManager).getVersion()
-		if err != nil {
-			t.Fatal(err)
-		}
 		if version.IsGreaterThan(internal.PklVersion0_25) {
 			t.SkipNow()
 		}
@@ -659,6 +650,35 @@ class Bar {
 			}
 		})
 		assert.ErrorContains(t, err, "http options are not supported on Pkl versions lower than 0.26")
+	})
+
+	t.Run("WithProjectEvaluatorSettings refuses to load module past configured root dir", func(t *testing.T) {
+		if version.IsLessThan(internal.PklVersion0_32) {
+			t.SkipNow()
+		}
+
+		tempDir := t.TempDir()
+		projectFile := tempDir + "/PklProject"
+		writeFile(t, projectFile, `amends "pkl:Project"
+
+evaluatorSettings {
+  rootDir = "."
+}
+`)
+		project, err := LoadProject(context.Background(), projectFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		evaluator, err := manager.NewEvaluator(context.Background(), PreconfiguredOptions, WithProjectEvaluatorSettings(project))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = evaluator.EvaluateOutputText(context.Background(), FileSource("/foo.txt"))
+		if err == nil {
+			t.Logf("Expected an error but didn't get any")
+			t.FailNow()
+		}
+		assert.Contains(t, err.Error(), "it is not within the root directory")
 	})
 
 	t.Cleanup(func() {

--- a/pkl/project.go
+++ b/pkl/project.go
@@ -30,11 +30,12 @@ func init() {
 
 // Project is the go representation of pkl.Project.
 type Project struct {
-	ProjectFileUri    string                   `pkl:"projectFileUri"`
-	Package           *ProjectPackage          `pkl:"package"`
-	EvaluatorSettings ProjectEvaluatorSettings `pkl:"evaluatorSettings"`
-	Tests             []string                 `pkl:"tests"`
-	Annotations       []Object                 `pkl:"annotations"`
+	ProjectFileUri            string                   `pkl:"projectFileUri"`
+	Package                   *ProjectPackage          `pkl:"package"`
+	EvaluatorSettings         ProjectEvaluatorSettings `pkl:"evaluatorSettings"`
+	ResolvedEvaluatorSettings ProjectEvaluatorSettings `pkl:"resolvedEvaluatorSettings"`
+	Tests                     []string                 `pkl:"tests"`
+	Annotations               []Object                 `pkl:"annotations"`
 
 	// internal field; use Project.Dependencies instead.
 	// values are either Project or ProjectRemoteDependency
@@ -132,6 +133,12 @@ func (project *Project) Dependencies() *ProjectDependencies {
 // LoadProject loads a project definition from the specified path directory.
 func LoadProject(context context.Context, path string) (*Project, error) {
 	ev, err := NewEvaluator(context, PreconfiguredOptions)
+	defer func() {
+		cerr := ev.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
 	if err != nil {
 		return nil, err
 	}

--- a/pkl/project_test.go
+++ b/pkl/project_test.go
@@ -445,6 +445,12 @@ func TestLoadProjectWithTraceMode(t *testing.T) {
 
 func TestLoadProjectWithHeaders(t *testing.T) {
 	manager := NewEvaluatorManager()
+	defer func(manager EvaluatorManager) {
+		err := manager.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}(manager)
 	version, err := manager.(*evaluatorManager).getVersion()
 	if err != nil {
 		t.Fatal(err)

--- a/pkl/project_test.go
+++ b/pkl/project_test.go
@@ -212,18 +212,20 @@ func TestLoadProject(t *testing.T) {
 	writeFile(t, tempDir+"/hawks/PklProject", project1Contents)
 	writeFile(t, tempDir+"/storks/PklProject", project2Contents)
 	project, err := LoadProject(context.Background(), tempDir+"/hawks/PklProject")
+
+	manager := NewEvaluatorManager()
+	defer func() { _ = manager.Close() }()
+	version, err := manager.(*evaluatorManager).getVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if assert.NoError(t, err) {
 		t.Run("projectFileUri", func(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("file://%s/hawks/PklProject", tempDir), project.ProjectFileUri)
 		})
 
 		t.Run("annotations", func(t *testing.T) {
-			manager := NewEvaluatorManager()
-			defer func() { _ = manager.Close() }()
-			version, err := manager.(*evaluatorManager).getVersion()
-			if err != nil {
-				t.Fatal(err)
-			}
 			if version.IsLessThan(internal.PklVersion0_27) {
 				t.SkipNow()
 			}
@@ -248,6 +250,28 @@ func TestLoadProject(t *testing.T) {
 				AllowedResources:   &[]string{"baz:", "biz:"},
 			}
 			assert.Equal(t, expectedSettings, project.EvaluatorSettings)
+		})
+
+		t.Run("resolvedEvaluatorSettings", func(t *testing.T) {
+			if version.IsLessThan(internal.PklVersion0_31) {
+				t.SkipNow()
+			}
+			fals := false
+			expectedSettings := ProjectEvaluatorSettings{
+				Timeout: Duration{
+					Value: 5,
+					Unit:  Minute,
+				},
+				NoCache:            &fals,
+				RootDir:            tempDir + "/hawks",
+				ModuleCacheDir:     tempDir + "/hawks/cache",
+				Env:                map[string]string{"one": "1"},
+				ExternalProperties: map[string]string{"two": "2"},
+				ModulePath:         []string{tempDir + "/hawks/modulepath1", tempDir + "/hawks/modulepath2"},
+				AllowedModules:     &[]string{"foo:", "bar:"},
+				AllowedResources:   &[]string{"baz:", "biz:"},
+			}
+			assert.Equal(t, expectedSettings, project.ResolvedEvaluatorSettings)
 		})
 
 		t.Run("package", func(t *testing.T) {


### PR DESCRIPTION
This adds support for `resolvedEvaluatorSettings`.

This introduces a breaking change: the `WithProjectEvaluatorSettings` method now applies the _resolved_ evaluator settings.

The existing `NewProjectEvaluator` and derived methods determine whether to load resolved or unresolved evaluator settings based on the Pkl version.