### PR TITLE
fix: support for Pkl 0.32+ external reader property workingDir

### DIFF
--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -315,6 +315,7 @@ func (p *Proxy) toMessage() *msgapi.Proxy {
 type ExternalReader struct {
 	Executable string
 	Arguments  []string
+	WorkingDir string
 }
 
 func (r *ExternalReader) toMessage() *msgapi.ExternalReader {

--- a/pkl/evaluator_options.go
+++ b/pkl/evaluator_options.go
@@ -313,8 +313,17 @@ func (p *Proxy) toMessage() *msgapi.Proxy {
 }
 
 type ExternalReader struct {
+	// The absolute path to the executable, or a simple name.
+	//
+	// In the case of a simple name, it is resolved off of the `PATH` environment variable.
 	Executable string
-	Arguments  []string
+
+	// The command line arguments to pass to the process.
+	Arguments []string
+
+	// The working directory to use for the executable process.
+	//
+	// Added in Pkl 0.32.
 	WorkingDir string
 }
 

--- a/pkl/internal/msgapi/outgoing.go
+++ b/pkl/internal/msgapi/outgoing.go
@@ -111,6 +111,7 @@ type Proxy struct {
 type ExternalReader struct {
 	Executable string   `msgpack:"executable"`
 	Arguments  []string `msgpack:"arguments,omitempty"`
+	WorkingDir string   `msgpack:"workingDir,omitempty'`
 }
 
 type Checksums struct {

--- a/pkl/project.go
+++ b/pkl/project.go
@@ -99,6 +99,7 @@ type ProjectEvaluatorSettingsProxy struct {
 type ProjectEvaluatorSettingExternalReader struct {
 	Executable string   `pkl:"executable"`
 	Arguments  []string `pkl:"arguments"`
+	WorkingDir string   `pkl:"workingDir"`
 }
 
 func (project *Project) Dependencies() *ProjectDependencies {


### PR DESCRIPTION
This suppress decoding warning message like the following when using pkl Go module in the context of a Pkl project specifying external reader:

>... warn: Cannot find field on Go struct `pkl.ProjectEvaluatorSettingExternalReader` matching Pkl property `workingDir`. Ensure the Go structs are up to date with Pkl classes either through codegen or manually adding `pkl` tags.