### PR TITLE
Add fields for ref.Access isProperty, isSubscript

### DIFF
--- a/pkl/unmarshal_test.go
+++ b/pkl/unmarshal_test.go
@@ -511,31 +511,31 @@ func TestUnmarshal_Reference(t *testing.T) {
 			Domain: reference.DImpl{},
 			Data:   "hi",
 			Path: []pkl.ReferenceAccess{
-				{Property: &foo},
+				{Property: &foo, InternalIsProperty: true, InternalIsSubscript: false},
 			},
 		},
 		Res2: pkl.Reference[reference.D]{
 			Domain: reference.DImpl{},
 			Data:   "hi",
 			Path: []pkl.ReferenceAccess{
-				{Property: &bar},
-				{Key: "hi"},
+				{Property: &bar, InternalIsProperty: true, InternalIsSubscript: false},
+				{Key: "hi", InternalIsProperty: false, InternalIsSubscript: true},
 			},
 		},
 		Res3: pkl.Reference[reference.D]{
 			Domain: reference.DImpl{},
 			Data:   "hi",
 			Path: []pkl.ReferenceAccess{
-				{Property: &bar},
-				{},
+				{Property: &bar, InternalIsProperty: true, InternalIsSubscript: false},
+				{InternalIsProperty: false, InternalIsSubscript: true},
 			},
 		},
 		Res4: pkl.Reference[reference.D]{
 			Domain: reference.DImpl{},
 			Data:   "hi",
 			Path: []pkl.ReferenceAccess{
-				{Property: &baz},
-				{Key: reference.MapKey{Key: "foo"}},
+				{Property: &baz, InternalIsProperty: true, InternalIsSubscript: false},
+				{Key: reference.MapKey{Key: "foo"}, InternalIsProperty: false, InternalIsSubscript: true},
 			},
 		},
 	}, res)

--- a/pkl/values.go
+++ b/pkl/values.go
@@ -329,10 +329,16 @@ type ReferenceAccess struct {
 	// If this access is a subscript access, this will be the value of the key (which may be `nil`) and [Property] will be `nil`.
 	// If this is a property access, this will be `nil`.
 	Key any `pkl:"key"`
+
+	// Internal; use IsProperty method instead
+	InternalIsProperty bool `pkl:"isProperty"`
+
+	// Internal; use IsSubscript method instead
+	InternalIsSubscript bool `pkl:"isSubscript"`
 }
 
 // IsProperty indicates if this represents a property access.
-func (a ReferenceAccess) IsProperty() bool { return a.Property != nil }
+func (a ReferenceAccess) IsProperty() bool { return a.InternalIsProperty }
 
 // IsSubscript indicates if this represents a subscript access.
-func (a ReferenceAccess) IsSubscript() bool { return a.Property == nil }
+func (a ReferenceAccess) IsSubscript() bool { return a.InternalIsSubscript }


### PR DESCRIPTION
These fields are currently missing and cause an emitted warning during unmarshal