### PR TITLE
Reject non-absolute file URLs in NewProjectEvaluator

### DIFF
--- a/pkl/evaluator_exec.go
+++ b/pkl/evaluator_exec.go
@@ -57,13 +57,12 @@ func NewProjectEvaluator(ctx context.Context, projectBaseUrl *url.URL, opts ...f
 // If creating multiple evaluators, prefer using EvaluatorManager.NewProjectEvaluator instead,
 // because it lessens the overhead of each successive evaluator.
 func NewProjectEvaluatorWithCommand(ctx context.Context, projectBaseUrl *url.URL, pklCmd []string, opts ...func(options *EvaluatorOptions)) (Evaluator, error) {
-	// A relative or otherwise non-absolute file URL (e.g. file://.) makes Pkl
-	// fail deep inside evaluation with an opaque PklBugException. Reject it up
-	// front with an actionable error instead.
+	// enforced by Pkl: `file` URIs must conform to RFC-8089.
+	// Pkl currently throws PklBugException if passing a file URI without a path
 	if projectBaseUrl.Scheme == "file" {
-		if host := projectBaseUrl.Host; (host != "" && host != "localhost") || !strings.HasPrefix(projectBaseUrl.Path, "/") {
+		if !strings.HasPrefix(projectBaseUrl.Path, "/") {
 			return nil, fmt.Errorf(
-				"projectBaseUrl %q must be an absolute file URL (e.g. file:///path/to/project); relative file URLs such as file://. are not supported",
+				"projectBaseUrl is an invalid file URI: file URIs must have a path component that starts with `/` (e.g. file:///path/to/project). Got: %q",
 				projectBaseUrl,
 			)
 		}

--- a/pkl/evaluator_exec.go
+++ b/pkl/evaluator_exec.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/apple/pkl-go/pkl/internal"
 )
@@ -56,6 +57,17 @@ func NewProjectEvaluator(ctx context.Context, projectBaseUrl *url.URL, opts ...f
 // If creating multiple evaluators, prefer using EvaluatorManager.NewProjectEvaluator instead,
 // because it lessens the overhead of each successive evaluator.
 func NewProjectEvaluatorWithCommand(ctx context.Context, projectBaseUrl *url.URL, pklCmd []string, opts ...func(options *EvaluatorOptions)) (Evaluator, error) {
+	// A relative or otherwise non-absolute file URL (e.g. file://.) makes Pkl
+	// fail deep inside evaluation with an opaque PklBugException. Reject it up
+	// front with an actionable error instead.
+	if projectBaseUrl.Scheme == "file" {
+		if host := projectBaseUrl.Host; (host != "" && host != "localhost") || !strings.HasPrefix(projectBaseUrl.Path, "/") {
+			return nil, fmt.Errorf(
+				"projectBaseUrl %q must be an absolute file URL (e.g. file:///path/to/project); relative file URLs such as file://. are not supported",
+				projectBaseUrl,
+			)
+		}
+	}
 	manager := NewEvaluatorManagerWithCommand(pklCmd)
 	projectEvaluator, err := manager.NewEvaluator(ctx, opts...)
 	if err != nil {

--- a/pkl/evaluator_exec_test.go
+++ b/pkl/evaluator_exec_test.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkl/evaluator_exec_test.go
+++ b/pkl/evaluator_exec_test.go
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+package pkl
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewProjectEvaluatorRejectsNonAbsoluteFileURL(t *testing.T) {
+	for _, raw := range []string{"file://.", "file://./sub", "file://relative/path"} {
+		u, err := url.Parse(raw)
+		assert.NoError(t, err)
+
+		// A non-absolute file URL previously reached Pkl and failed with an
+		// opaque PklBugException; it should now fail fast with an actionable
+		// error before any evaluator process is started.
+		ev, err := NewProjectEvaluator(context.Background(), u)
+		assert.Nil(t, ev, "expected no evaluator for %q", raw)
+		assert.ErrorContains(t, err, "absolute file URL", "for %q", raw)
+	}
+}

--- a/pkl/evaluator_exec_test.go
+++ b/pkl/evaluator_exec_test.go
@@ -24,16 +24,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewProjectEvaluatorRejectsNonAbsoluteFileURL(t *testing.T) {
-	for _, raw := range []string{"file://.", "file://./sub", "file://relative/path"} {
+func TestNewProjectEvaluatorRejectsFileURLWithoutPath(t *testing.T) {
+	for _, raw := range []string{"file://.", "file:.", "file://localhost"} {
 		u, err := url.Parse(raw)
 		assert.NoError(t, err)
 
-		// A non-absolute file URL previously reached Pkl and failed with an
+		// A file URI without a path previously reached Pkl and failed with an
 		// opaque PklBugException; it should now fail fast with an actionable
 		// error before any evaluator process is started.
 		ev, err := NewProjectEvaluator(context.Background(), u)
 		assert.Nil(t, ev, "expected no evaluator for %q", raw)
-		assert.ErrorContains(t, err, "absolute file URL", "for %q", raw)
+		assert.ErrorContains(t, err, "invalid file URI", "for %q", raw)
 	}
 }


### PR DESCRIPTION
## Summary

`NewProjectEvaluator` accepts a `*url.URL` for the project base. A relative file URL such as `file://.` is forwarded to Pkl, which fails deep in evaluation with an opaque `org.pkl.core.PklBugException` rather than a useful message. The pkl CLI handles the equivalent `--project-dir=.` fine because it resolves the path to an absolute one.

This validates `projectBaseUrl` up front: when the URL uses the `file` scheme, it must be absolute (empty/`localhost` host and an absolute path). Otherwise `NewProjectEvaluator` now returns an actionable error **before** starting an evaluator process, instead of letting Pkl crash.

```
projectBaseUrl "file://." must be an absolute file URL (e.g. file:///path/to/project); relative file URLs such as file://. are not supported
```

Fixes #185.

## Test

Added `TestNewProjectEvaluatorRejectsNonAbsoluteFileURL` covering `file://.`, `file://./sub`, and `file://relative/path`. The validation runs before any evaluator process is spawned, so the test does not require a `pkl` binary. It fails before the change (the call falls through toward evaluation) and passes after.

Non-`file` schemes (e.g. `package://`) are unaffected.