### PR TITLE
Propagate ctx cancellation instead of swallowing it as nil

### DIFF
--- a/pkl/evaluator.go
+++ b/pkl/evaluator.go
@@ -129,7 +129,7 @@ func (e *evaluator) EvaluateExpressionRaw(ctx context.Context, source *ModuleSou
 		return nil, fmt.Errorf("evaluator is closed")
 	}
 	requestId := random.Int63()
-	ch := make(chan *msgapi.EvaluateResponse)
+	ch := make(chan *msgapi.EvaluateResponse, 1)
 	e.pendingRequests.Store(requestId, ch)
 	interrupted, nevermind := e.manager.interrupted(e.evaluatorId)
 	defer nevermind()
@@ -142,8 +142,10 @@ func (e *evaluator) EvaluateExpressionRaw(ctx context.Context, source *ModuleSou
 	}
 	select {
 	case <-ctx.Done():
-		return nil, nil
+		e.pendingRequests.Delete(requestId)
+		return nil, ctx.Err()
 	case err := <-interrupted:
+		e.pendingRequests.Delete(requestId)
 		return nil, err
 	case resp := <-ch:
 		if resp.Error != "" {

--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -110,7 +110,7 @@ func (m *evaluatorManager) NewEvaluator(ctx context.Context, opts ...func(option
 	msg := o.toMessage()
 	msg.RequestId = requestId
 	newEvaluatorRequest = msg
-	ch := make(chan *msgapi.CreateEvaluatorResponse)
+	ch := make(chan *msgapi.CreateEvaluatorResponse, 1)
 	m.pendingEvaluators.Store(requestId, ch)
 	interrupt, nevermind := m.interrupted(0)
 	defer nevermind()
@@ -123,8 +123,10 @@ func (m *evaluatorManager) NewEvaluator(ctx context.Context, opts ...func(option
 	}
 	select {
 	case <-ctx.Done():
-		return nil, nil
+		m.pendingEvaluators.Delete(requestId)
+		return nil, ctx.Err()
 	case err := <-interrupt:
+		m.pendingEvaluators.Delete(requestId)
 		return nil, err
 	case resp := <-ch:
 		if resp.Error != "" {

--- a/pkl/evaluator_manager_test.go
+++ b/pkl/evaluator_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/apple/pkl-go/pkl/internal"
 	"github.com/apple/pkl-go/pkl/internal/msgapi"
@@ -97,4 +98,72 @@ func TestEvaluatorManager_interrupt_Close(t *testing.T) {
 	evaluator, err := m.NewEvaluator(context.Background())
 	assert.Nil(t, evaluator)
 	assert.Nil(t, err)
+}
+
+// TestEvaluator_EvaluateExpressionRaw_CtxCancel verifies that a cancelled context
+// surfaces as ctx.Err() (not a swallowed (nil, nil)), that the pendingRequests
+// entry is cleaned up, and that a response which arrives after the caller has
+// already given up does not block the manager's shared listen() goroutine -
+// which previously would deadlock every future evaluation on this evaluator.
+func TestEvaluator_EvaluateExpressionRaw_CtxCancel(t *testing.T) {
+	m := newFakeEvaluatorManager()
+	go m.listen()
+
+	requestIdCh := make(chan int64, 1)
+	go func() {
+		msg := <-m.impl.outChan()
+		if ev, ok := msg.(*msgapi.Evaluate); ok {
+			requestIdCh <- ev.RequestId
+		}
+	}()
+
+	ev := &evaluator{
+		evaluatorId:     1,
+		manager:         m,
+		pendingRequests: &sync.Map{},
+	}
+	m.evaluators.Store(int64(1), ev)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := ev.EvaluateExpressionRaw(ctx, TextSource("foo"), "output.text")
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	var requestId int64
+	select {
+	case requestId = <-requestIdCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the Evaluate request to be sent")
+	}
+
+	_, exists := ev.pendingRequests.Load(requestId)
+	assert.False(t, exists, "pendingRequests entry should be cleaned up after ctx cancellation")
+
+	// Simulate the pkl process finishing the evaluation after the caller already
+	// gave up. Before this fix, handleEvaluateResponse would block forever
+	// sending on the abandoned, unbuffered response channel, wedging listen()
+	// for every other evaluation on this evaluator. A second, unrelated
+	// response is sent afterwards as a sentinel: since the fake inChan is
+	// itself unbuffered, listen() can only receive it once it has returned
+	// from handling the first (proving it didn't get stuck inside it).
+	done := make(chan struct{})
+	go func() {
+		m.impl.inChan() <- &msgapi.EvaluateResponse{
+			RequestId:   requestId,
+			EvaluatorId: 1,
+			Result:      []byte("late response"),
+		}
+		m.impl.inChan() <- &msgapi.EvaluateResponse{
+			RequestId:   requestId + 1, // unknown request id: handled as a harmless no-op
+			EvaluatorId: 1,
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listen() appears deadlocked processing a response for an abandoned request")
+	}
 }


### PR DESCRIPTION
Fixes #261

## Summary

`EvaluateExpressionRaw` and `NewEvaluator` returned `(nil, nil)` when their
`ctx` was cancelled or timed out, instead of the context error. Callers then
unmarshal the `nil` result, which fails with a generic `io.EOF` -
indistinguishable from a real decode error, and hiding that the operation
actually timed out.

Worse, the abandoned, unbuffered response channel was never removed from
`pendingRequests`/`pendingEvaluators`. If the pkl process replies after the
caller has already given up, `evaluatorManager.listen()` - the single
goroutine dispatching all messages for an evaluator - blocks forever sending
on that channel, permanently wedging every subsequent evaluation on the same
evaluator until the process is restarted.

## Changes

- `pkl/evaluator.go`: `EvaluateExpressionRaw` returns `ctx.Err()` (and the
  `interrupted` error) instead of `nil, nil`; deletes the `pendingRequests`
  entry immediately on that path; buffers the response channel so a racing
  late response can't block the dispatch goroutine even if it wins the race.
- `pkl/evaluator_manager.go`: same fix applied to `NewEvaluator`'s analogous
  `pendingEvaluators` path.
- `pkl/evaluator_manager_test.go`: adds a regression test using the existing
  `fakeEvaluatorImpl` harness that (1) cancels the context and asserts
  `ctx.Err()` is returned, (2) asserts the pending-request entry is cleaned
  up, and (3) delivers a "late" response after cancellation and asserts
  `listen()` is not deadlocked by sending a second sentinel message through
  afterward. Verified this test fails/hangs against the pre-fix code and
  passes against the fix.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] New regression test confirmed to fail (times out) against the
      unpatched code, and pass against the fix