### PR TITLE
Prevent evaluator dispatcher deadlocks

### DIFF
--- a/pkl/evaluator.go
+++ b/pkl/evaluator.go
@@ -129,8 +129,9 @@ func (e *evaluator) EvaluateExpressionRaw(ctx context.Context, source *ModuleSou
 		return nil, fmt.Errorf("evaluator is closed")
 	}
 	requestId := random.Int63()
-	ch := make(chan *msgapi.EvaluateResponse)
+	ch := make(chan *msgapi.EvaluateResponse, 1)
 	e.pendingRequests.Store(requestId, ch)
+	defer e.pendingRequests.Delete(requestId)
 	interrupted, nevermind := e.manager.interrupted(e.evaluatorId)
 	defer nevermind()
 	e.manager.impl.outChan() <- &msgapi.Evaluate{
@@ -142,8 +143,11 @@ func (e *evaluator) EvaluateExpressionRaw(ctx context.Context, source *ModuleSou
 	}
 	select {
 	case <-ctx.Done():
-		return nil, nil
+		return nil, ctx.Err()
 	case err := <-interrupted:
+		if err == nil {
+			return nil, fmt.Errorf("evaluator is closed")
+		}
 		return nil, err
 	case resp := <-ch:
 		if resp.Error != "" {
@@ -166,15 +170,13 @@ func (e *evaluator) Closed() bool {
 }
 
 func (e *evaluator) handleEvaluateResponse(resp *msgapi.EvaluateResponse) {
-	c, exists := e.pendingRequests.Load(resp.RequestId)
+	c, exists := e.pendingRequests.LoadAndDelete(resp.RequestId)
 	if !exists {
 		log.Default().Printf("warn: received a message for an unknown request id: %d", resp.RequestId)
 		return
 	}
 	ch := c.(chan *msgapi.EvaluateResponse)
 	ch <- resp
-	close(ch)
-	e.pendingRequests.Delete(resp.RequestId)
 }
 
 func (e *evaluator) handleLog(resp *msgapi.Log) {

--- a/pkl/evaluator_manager.go
+++ b/pkl/evaluator_manager.go
@@ -110,8 +110,9 @@ func (m *evaluatorManager) NewEvaluator(ctx context.Context, opts ...func(option
 	msg := o.toMessage()
 	msg.RequestId = requestId
 	newEvaluatorRequest = msg
-	ch := make(chan *msgapi.CreateEvaluatorResponse)
+	ch := make(chan *msgapi.CreateEvaluatorResponse, 1)
 	m.pendingEvaluators.Store(requestId, ch)
+	defer m.pendingEvaluators.Delete(requestId)
 	interrupt, nevermind := m.interrupted(0)
 	defer nevermind()
 	go func() {
@@ -119,12 +120,15 @@ func (m *evaluatorManager) NewEvaluator(ctx context.Context, opts ...func(option
 	}()
 	// sanity check: it's possible that the evaluator has been closed at this point.
 	if m.closed.get() {
-		return nil, nil
+		return nil, errors.New("EvaluatorManager has been closed")
 	}
 	select {
 	case <-ctx.Done():
-		return nil, nil
+		return nil, ctx.Err()
 	case err := <-interrupt:
+		if err == nil {
+			return nil, errors.New("EvaluatorManager has been closed")
+		}
 		return nil, err
 	case resp := <-ch:
 		if resp.Error != "" {
@@ -204,49 +208,47 @@ func (m *evaluatorManager) listen() {
 		case *msgapi.EvaluateResponse:
 			ev := m.getEvaluator(msg.EvaluatorId)
 			if ev == nil {
-				return
+				continue
 			}
 			ev.handleEvaluateResponse(msg)
 		case *msgapi.Log:
 			ev := m.getEvaluator(msg.EvaluatorId)
 			if ev == nil {
-				return
+				continue
 			}
 			ev.handleLog(msg)
 		case *msgapi.ReadResource:
 			ev := m.getEvaluator(msg.EvaluatorId)
 			if ev == nil {
-				return
+				continue
 			}
 			ev.handleReadResource(msg)
 		case *msgapi.ReadModule:
 			ev := m.getEvaluator(msg.EvaluatorId)
 			if ev == nil {
-				return
+				continue
 			}
 			ev.handleReadModule(msg)
 		case *msgapi.ListResources:
 			ev := m.getEvaluator(msg.EvaluatorId)
 			if ev == nil {
-				return
+				continue
 			}
 			ev.handleListResources(msg)
 		case *msgapi.ListModules:
 			ev := m.getEvaluator(msg.EvaluatorId)
 			if ev == nil {
-				return
+				continue
 			}
 			ev.handleListModules(msg)
 		case *msgapi.CreateEvaluatorResponse:
-			ch, exists := m.pendingEvaluators.Load(msg.RequestId)
+			ch, exists := m.pendingEvaluators.LoadAndDelete(msg.RequestId)
 			if !exists {
 				log.Default().Printf("warn: received a message for an unknown request id: %d", msg.RequestId)
-				return
+				continue
 			}
 			cch := ch.(chan *msgapi.CreateEvaluatorResponse)
 			cch <- msg
-			close(cch)
-			m.pendingEvaluators.Delete(msg.RequestId)
 		}
 	}
 }

--- a/pkl/evaluator_manager_test.go
+++ b/pkl/evaluator_manager_test.go
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkl/evaluator_manager_test.go
+++ b/pkl/evaluator_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/apple/pkl-go/pkl/internal"
 	"github.com/apple/pkl-go/pkl/internal/msgapi"
@@ -76,6 +77,113 @@ func newFakeEvaluatorManager() *evaluatorManager {
 	}
 }
 
+func syncMapLen(m *sync.Map) int {
+	length := 0
+	m.Range(func(_, _ any) bool {
+		length++
+		return true
+	})
+	return length
+}
+
+func TestEvaluatorManager_listenContinuesAfterUnknownCreateEvaluatorResponse(t *testing.T) {
+	m := newFakeEvaluatorManager()
+	impl := m.impl.(*fakeEvaluatorImpl)
+	impl.in = make(chan msgapi.IncomingMessage, 2)
+
+	const knownRequestID int64 = 1
+	response := make(chan *msgapi.CreateEvaluatorResponse, 1)
+	m.pendingEvaluators.Store(knownRequestID, response)
+	impl.in <- &msgapi.CreateEvaluatorResponse{RequestId: 2}
+	impl.in <- &msgapi.CreateEvaluatorResponse{RequestId: knownRequestID}
+	close(impl.in)
+
+	go m.listen()
+	select {
+	case <-response:
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher stopped after an unknown create evaluator response")
+	}
+}
+
+func TestEvaluatorManager_lateCreateEvaluatorResponseDoesNotBlockDispatcher(t *testing.T) {
+	m := newFakeEvaluatorManager()
+	impl := m.impl.(*fakeEvaluatorImpl)
+	impl.in = make(chan msgapi.IncomingMessage, 2)
+	impl.out = make(chan msgapi.OutgoingMessage, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	evaluator, err := m.NewEvaluator(ctx)
+	assert.Nil(t, evaluator)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	request := (<-impl.out).(*msgapi.CreateEvaluator)
+	subsequentRequestID := request.RequestId + 1
+	subsequentResponse := make(chan *msgapi.CreateEvaluatorResponse, 1)
+	m.pendingEvaluators.Store(subsequentRequestID, subsequentResponse)
+	impl.in <- &msgapi.CreateEvaluatorResponse{RequestId: request.RequestId}
+	impl.in <- &msgapi.CreateEvaluatorResponse{RequestId: subsequentRequestID}
+	close(impl.in)
+
+	go m.listen()
+	select {
+	case <-subsequentResponse:
+	case <-time.After(time.Second):
+		t.Fatal("late create evaluator response blocked the dispatcher")
+	}
+}
+
+func TestEvaluatorManager_NewEvaluatorWithCanceledContext(t *testing.T) {
+	m := newFakeEvaluatorManager()
+	impl := m.impl.(*fakeEvaluatorImpl)
+	impl.out = make(chan msgapi.OutgoingMessage, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	evaluator, err := m.NewEvaluator(ctx)
+
+	assert.Nil(t, evaluator)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, syncMapLen(m.pendingEvaluators))
+}
+
+func TestEvaluator_EvaluateExpressionRawWithCanceledContext(t *testing.T) {
+	m := newFakeEvaluatorManager()
+	impl := m.impl.(*fakeEvaluatorImpl)
+	impl.in = make(chan msgapi.IncomingMessage, 2)
+	impl.out = make(chan msgapi.OutgoingMessage, 1)
+	e := &evaluator{
+		evaluatorId:     1,
+		manager:         m,
+		pendingRequests: &sync.Map{},
+	}
+	m.evaluators.Store(e.evaluatorId, e)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err := e.EvaluateExpressionRaw(ctx, TextSource("42"), "")
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, syncMapLen(e.pendingRequests))
+
+	request := (<-impl.out).(*msgapi.Evaluate)
+	subsequentRequestID := request.RequestId + 1
+	subsequentResponse := make(chan *msgapi.CreateEvaluatorResponse, 1)
+	m.pendingEvaluators.Store(subsequentRequestID, subsequentResponse)
+	impl.in <- &msgapi.EvaluateResponse{RequestId: request.RequestId, EvaluatorId: e.evaluatorId}
+	impl.in <- &msgapi.CreateEvaluatorResponse{RequestId: subsequentRequestID}
+	close(impl.in)
+
+	go m.listen()
+	select {
+	case <-subsequentResponse:
+	case <-time.After(time.Second):
+		t.Fatal("late evaluate response blocked the dispatcher")
+	}
+}
+
 func TestEvaluatorManager_interrupt_NewEvaluator(t *testing.T) {
 	m := newFakeEvaluatorManager()
 	defer assert.NoError(t, m.Close())
@@ -96,5 +204,5 @@ func TestEvaluatorManager_interrupt_Close(t *testing.T) {
 	}()
 	evaluator, err := m.NewEvaluator(context.Background())
 	assert.Nil(t, evaluator)
-	assert.Nil(t, err)
+	assert.EqualError(t, err, "EvaluatorManager has been closed")
 }


### PR DESCRIPTION
## Summary

A downstream consumer repeatedly hung during concurrent module loading. Every observed hang stopped after logging an unknown request ID, left both the consumer and Pkl child alive, and never dispatched another evaluation response.

The evaluator manager has one goroutine reading incoming messages. A late or unmatched CreateEvaluatorResponse made that goroutine return, so all later responses remained undispatched. A second path could block the same goroutine forever: NewEvaluator could return after cancellation while leaving an unbuffered response channel in pendingEvaluators, then a late response would block while sending to the abandoned channel. EvaluateExpressionRaw had the analogous cancellation and channel behavior.

This change keeps the dispatcher alive after unmatched messages, uses one-element response channels, and removes pending entries on every request exit. Unknown evaluator IDs in the other dispatcher arms are handled consistently and no longer terminate the listener.

The cancellation portion overlaps #262 by @ishaagg29. This PR keeps that behavior and adds the unknown-response, closed-manager, guaranteed-cleanup, and dispatcher-survival fixes needed for the observed production failure.

## API behavior change

NewEvaluator and EvaluateExpressionRaw now return ctx.Err() when their context is canceled or reaches its deadline. Concurrent manager or evaluator closure also returns a non-nil close error. These paths previously returned a nil evaluator or result with a nil error; EvaluateExpression could consequently surface an unrelated decode EOF.

## Regression coverage

The tests verify that:

- an unknown CreateEvaluatorResponse does not stop later dispatch;
- a response arriving after canceled evaluator creation cannot block dispatch;
- canceled NewEvaluator returns context.Canceled and leaves pendingEvaluators empty;
- canceled EvaluateExpressionRaw returns context.Canceled, cleans pendingRequests, and cannot block later dispatch; and
- concurrent manager closure no longer returns a nil evaluator with a nil error.

With only the regression tests applied, the first two dispatcher tests timed out and the cancellation tests observed nil errors and leaked map entries. All pass with this fix.

## Test plan

- go test -race ./... with Pkl 0.25.3
- go test -race ./... with Pkl 0.32.0
- ./scripts/test_snippets.sh with Pkl 0.32.0
- pkl test --project-dir codegen/src/ with Pkl 0.32.0
- pkl format --diff-name-only .
- gofumpt -d .

By submitting this pull request, I acknowledge that I have the right to license this contribution to Apple and the community and agree that it is licensed under the Apache 2.0 license.